### PR TITLE
Clean up whitespace

### DIFF
--- a/src/pffi.sls
+++ b/src/pffi.sls
@@ -31,103 +31,103 @@
 #!r6rs
 (library (pffi)
     (export foreign-procedure
-	    c-callback
-	    free-c-callback
-	    open-shared-object
-	    ;; TODO should we export these primitives?
-	    ;; lookup-shared-object
-	    ;; make-c-function
-	    ;; make-c-callback
+            c-callback
+            free-c-callback
+            open-shared-object
+            ;; TODO should we export these primitives?
+            ;; lookup-shared-object
+            ;; make-c-function
+            ;; make-c-callback
 
-	    ;; primitive types
-	    char  unsigned-char
-	    short unsigned-short
-	    int   unsigned-int
-	    long  unsigned-long
-	    float double
-	    int8_t  uint8_t
-	    int16_t uint16_t
-	    int32_t uint32_t
-	    int64_t uint64_t
-	    pointer callback
-	    void
+            ;; primitive types
+            char  unsigned-char
+            short unsigned-short
+            int   unsigned-int
+            long  unsigned-long
+            float double
+            int8_t  uint8_t
+            int16_t uint16_t
+            int32_t uint32_t
+            int64_t uint64_t
+            pointer callback
+            void
 
-	    size-of-char
-	    size-of-short
-	    size-of-int
-	    size-of-long
-	    size-of-float
-	    size-of-double
-	    size-of-pointer
-	    size-of-int8_t
-	    size-of-int16_t
-	    size-of-int32_t
-	    size-of-int64_t
-	    size-of-uint8_t
-	    size-of-uint16_t
-	    size-of-uint32_t
-	    size-of-uint64_t
+            size-of-char
+            size-of-short
+            size-of-int
+            size-of-long
+            size-of-float
+            size-of-double
+            size-of-pointer
+            size-of-int8_t
+            size-of-int16_t
+            size-of-int32_t
+            size-of-int64_t
+            size-of-uint8_t
+            size-of-uint16_t
+            size-of-uint32_t
+            size-of-uint64_t
 
-	    ;; pointer ref
-	    pointer-ref-c-uint8
-	    pointer-ref-c-int8
-	    pointer-ref-c-uint16
-	    pointer-ref-c-int16
-	    pointer-ref-c-uint32
-	    pointer-ref-c-int32
-	    pointer-ref-c-uint64
-	    pointer-ref-c-int64
-	    pointer-ref-c-unsigned-char
-	    pointer-ref-c-char
-	    pointer-ref-c-unsigned-short
-	    pointer-ref-c-short
-	    pointer-ref-c-unsigned-int
-	    pointer-ref-c-int
-	    pointer-ref-c-unsigned-long
-	    pointer-ref-c-long
-	    pointer-ref-c-float
-	    pointer-ref-c-double
-	    pointer-ref-c-pointer
+            ;; pointer ref
+            pointer-ref-c-uint8
+            pointer-ref-c-int8
+            pointer-ref-c-uint16
+            pointer-ref-c-int16
+            pointer-ref-c-uint32
+            pointer-ref-c-int32
+            pointer-ref-c-uint64
+            pointer-ref-c-int64
+            pointer-ref-c-unsigned-char
+            pointer-ref-c-char
+            pointer-ref-c-unsigned-short
+            pointer-ref-c-short
+            pointer-ref-c-unsigned-int
+            pointer-ref-c-int
+            pointer-ref-c-unsigned-long
+            pointer-ref-c-long
+            pointer-ref-c-float
+            pointer-ref-c-double
+            pointer-ref-c-pointer
 
-	    ;; pointer set
-	    pointer-set-c-uint8!
-	    pointer-set-c-int8!
-	    pointer-set-c-uint16!
-	    pointer-set-c-int16!
-	    pointer-set-c-uint32!
-	    pointer-set-c-int32!
-	    pointer-set-c-uint64!
-	    pointer-set-c-int64!
-	    pointer-set-c-unsigned-char!
-	    pointer-set-c-char!
-	    pointer-set-c-unsigned-short!
-	    pointer-set-c-short!
-	    pointer-set-c-unsigned-int!
-	    pointer-set-c-int!
-	    pointer-set-c-unsigned-long!
-	    pointer-set-c-long!
-	    pointer-set-c-float!
-	    pointer-set-c-double!
-	    pointer-set-c-pointer!
+            ;; pointer set
+            pointer-set-c-uint8!
+            pointer-set-c-int8!
+            pointer-set-c-uint16!
+            pointer-set-c-int16!
+            pointer-set-c-uint32!
+            pointer-set-c-int32!
+            pointer-set-c-uint64!
+            pointer-set-c-int64!
+            pointer-set-c-unsigned-char!
+            pointer-set-c-char!
+            pointer-set-c-unsigned-short!
+            pointer-set-c-short!
+            pointer-set-c-unsigned-int!
+            pointer-set-c-int!
+            pointer-set-c-unsigned-long!
+            pointer-set-c-long!
+            pointer-set-c-float!
+            pointer-set-c-double!
+            pointer-set-c-pointer!
 
-	    ;; variable
-	    define-foreign-variable
+            ;; variable
+            define-foreign-variable
 
-	    pointer?
-	    bytevector->pointer
-	    pointer->bytevector
-	    pointer->integer
-	    integer->pointer
+            pointer?
+            bytevector->pointer
+            pointer->bytevector
+            pointer->integer
+            integer->pointer
 
-	    ;; struct
-	    define-foreign-struct
-	    define-foreign-union
-	    )
+            ;; struct
+            define-foreign-struct
+            define-foreign-union
+            )
     (import (pffi procedure)
-	    (pffi variable)
-	    (pffi pointers)
-	    (pffi struct)
-	    (only (rnrs) define))
+            (pffi variable)
+            (pffi pointers)
+            (pffi struct)
+            (only (rnrs) define))
 
 (define size-of-uint8_t  size-of-int8_t)
 (define size-of-uint16_t size-of-int16_t)

--- a/src/pffi/bv-pointer.chezscheme.sls
+++ b/src/pffi/bv-pointer.chezscheme.sls
@@ -1,20 +1,20 @@
 ;;; -*- mode:scheme; coding: utf-8; -*-
 ;;;
 ;;; src/pffi/bv-pointer.chezscheme.sls - Compatible layer of compatible layer
-;;;  
+;;;
 ;;;   Copyright (c) 2018  Takashi Kato  <ktakashi@ymail.com>
-;;;   
+;;;
 ;;;   Redistribution and use in source and binary forms, with or without
 ;;;   modification, are permitted provided that the following conditions
 ;;;   are met:
-;;;   
+;;;
 ;;;   1. Redistributions of source code must retain the above copyright
 ;;;      notice, this list of conditions and the following disclaimer.
-;;;  
+;;;
 ;;;   2. Redistributions in binary form must reproduce the above copyright
 ;;;      notice, this list of conditions and the following disclaimer in the
 ;;;      documentation and/or other materials provided with the distribution.
-;;;  
+;;;
 ;;;   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
 ;;;   "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
 ;;;   LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
@@ -26,16 +26,16 @@
 ;;;   LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
 ;;;   NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 ;;;   SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-;;;  
+;;;
 
 #!r6rs
 (library (pffi bv-pointer)
     (export bytevector->pointer)
     (import (rnrs)
-	    (only (chezscheme)
-		  machine-type foreign-procedure load-shared-object))
+            (only (chezscheme)
+                  machine-type foreign-procedure load-shared-object))
 
-(define dummy 
+(define dummy
   (case (machine-type)
     ((ta6le a6le i3le ti3le arm32le ppc32le) (load-shared-object "libc.so.6"))
     ((i3osx ti3osx a6osx ta6osx) (load-shared-object "libc.dylib"))

--- a/src/pffi/bv-pointer.mosh.sls
+++ b/src/pffi/bv-pointer.mosh.sls
@@ -1,20 +1,20 @@
 ;;; -*- mode:scheme; coding: utf-8; -*-
 ;;;
 ;;; src/pffi/bv-pointer.nmosh.sls - Compatible layer of compatible layer
-;;;  
+;;;
 ;;;   Copyright (c) 2015  Takashi Kato  <ktakashi@ymail.com>
-;;;   
+;;;
 ;;;   Redistribution and use in source and binary forms, with or without
 ;;;   modification, are permitted provided that the following conditions
 ;;;   are met:
-;;;   
+;;;
 ;;;   1. Redistributions of source code must retain the above copyright
 ;;;      notice, this list of conditions and the following disclaimer.
-;;;  
+;;;
 ;;;   2. Redistributions in binary form must reproduce the above copyright
 ;;;      notice, this list of conditions and the following disclaimer in the
 ;;;      documentation and/or other materials provided with the distribution.
-;;;  
+;;;
 ;;;   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
 ;;;   "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
 ;;;   LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
@@ -26,7 +26,7 @@
 ;;;   LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
 ;;;   NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 ;;;   SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-;;;  
+;;;
 
 #!r6rs
 

--- a/src/pffi/bv-pointer.nmosh.sls
+++ b/src/pffi/bv-pointer.nmosh.sls
@@ -1,20 +1,20 @@
 ;;; -*- mode:scheme; coding: utf-8; -*-
 ;;;
 ;;; src/pffi/bv-pointer.nmosh.sls - Compatible layer of compatible layer
-;;;  
+;;;
 ;;;   Copyright (c) 2015  Takashi Kato  <ktakashi@ymail.com>
-;;;   
+;;;
 ;;;   Redistribution and use in source and binary forms, with or without
 ;;;   modification, are permitted provided that the following conditions
 ;;;   are met:
-;;;   
+;;;
 ;;;   1. Redistributions of source code must retain the above copyright
 ;;;      notice, this list of conditions and the following disclaimer.
-;;;  
+;;;
 ;;;   2. Redistributions in binary form must reproduce the above copyright
 ;;;      notice, this list of conditions and the following disclaimer in the
 ;;;      documentation and/or other materials provided with the distribution.
-;;;  
+;;;
 ;;;   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
 ;;;   "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
 ;;;   LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
@@ -26,7 +26,7 @@
 ;;;   LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
 ;;;   NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 ;;;   SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-;;;  
+;;;
 
 #!r6rs
 ;; kinda silly but seems there is no way to get

--- a/src/pffi/compat.chezscheme.sls
+++ b/src/pffi/compat.chezscheme.sls
@@ -1,20 +1,20 @@
 ;;; -*- mode:scheme; coding: utf-8; -*-
 ;;;
 ;;; src/pffi/compat.chezscheme.sls - Compatible layer for Chez Scheme
-;;;  
+;;;
 ;;;   Copyright (c) 2018  Takashi Kato  <ktakashi@ymail.com>
-;;;   
+;;;
 ;;;   Redistribution and use in source and binary forms, with or without
 ;;;   modification, are permitted provided that the following conditions
 ;;;   are met:
-;;;   
+;;;
 ;;;   1. Redistributions of source code must retain the above copyright
 ;;;      notice, this list of conditions and the following disclaimer.
-;;;  
+;;;
 ;;;   2. Redistributions in binary form must reproduce the above copyright
 ;;;      notice, this list of conditions and the following disclaimer in the
 ;;;      documentation and/or other materials provided with the distribution.
-;;;  
+;;;
 ;;;   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
 ;;;   "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
 ;;;   LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
@@ -26,7 +26,7 @@
 ;;;   LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
 ;;;   NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 ;;;   SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-;;;  
+;;;
 
 ;; this file provides compatible layer for (pffi procedure)
 ;; if implementations can't make this layer, then make
@@ -36,95 +36,95 @@
 #!r6rs
 (library (pffi compat)
     (export open-shared-object
-	    lookup-shared-object
-	    make-c-function
-	    make-c-callback
-	    free-c-callback
+            lookup-shared-object
+            make-c-function
+            make-c-callback
+            free-c-callback
 
-	    ;; primitive types
-	    char  unsigned-char
-	    short unsigned-short
-	    int   unsigned-int
-	    long  unsigned-long
-	    float double
-	    int8_t  uint8_t
-	    int16_t uint16_t
-	    int32_t uint32_t
-	    int64_t uint64_t
-	    pointer callback
-	    void
+            ;; primitive types
+            char  unsigned-char
+            short unsigned-short
+            int   unsigned-int
+            long  unsigned-long
+            float double
+            int8_t  uint8_t
+            int16_t uint16_t
+            int32_t uint32_t
+            int64_t uint64_t
+            pointer callback
+            void
 
-	    ;; pointer ref
-	    pointer-ref-c-uint8
-	    pointer-ref-c-int8
-	    pointer-ref-c-uint16
-	    pointer-ref-c-int16
-	    pointer-ref-c-uint32
-	    pointer-ref-c-int32
-	    pointer-ref-c-uint64
-	    pointer-ref-c-int64
-	    pointer-ref-c-unsigned-char
-	    pointer-ref-c-char
-	    pointer-ref-c-unsigned-short
-	    pointer-ref-c-short
-	    pointer-ref-c-unsigned-int
-	    pointer-ref-c-int
-	    pointer-ref-c-unsigned-long
-	    pointer-ref-c-long
-	    pointer-ref-c-float
-	    pointer-ref-c-double
-	    pointer-ref-c-pointer
+            ;; pointer ref
+            pointer-ref-c-uint8
+            pointer-ref-c-int8
+            pointer-ref-c-uint16
+            pointer-ref-c-int16
+            pointer-ref-c-uint32
+            pointer-ref-c-int32
+            pointer-ref-c-uint64
+            pointer-ref-c-int64
+            pointer-ref-c-unsigned-char
+            pointer-ref-c-char
+            pointer-ref-c-unsigned-short
+            pointer-ref-c-short
+            pointer-ref-c-unsigned-int
+            pointer-ref-c-int
+            pointer-ref-c-unsigned-long
+            pointer-ref-c-long
+            pointer-ref-c-float
+            pointer-ref-c-double
+            pointer-ref-c-pointer
 
-	    ;; pointer set
-	    pointer-set-c-uint8!
-	    pointer-set-c-int8!
-	    pointer-set-c-uint16!
-	    pointer-set-c-int16!
-	    pointer-set-c-uint32!
-	    pointer-set-c-int32!
-	    pointer-set-c-uint64!
-	    pointer-set-c-int64!
-	    pointer-set-c-unsigned-char!
-	    pointer-set-c-char!
-	    pointer-set-c-unsigned-short!
-	    pointer-set-c-short!
-	    pointer-set-c-unsigned-int!
-	    pointer-set-c-int!
-	    pointer-set-c-unsigned-long!
-	    pointer-set-c-long!
-	    pointer-set-c-float!
-	    pointer-set-c-double!
-	    pointer-set-c-pointer!
-	    
-	    ;; sizeof
-	    size-of-char
-	    size-of-short
-	    size-of-int
-	    size-of-long
-	    size-of-float
-	    size-of-double
-	    size-of-pointer
-	    (rename (size-of-int8 size-of-int8_t)
-		    (size-of-int16 size-of-int16_t)
-		    (size-of-int32 size-of-int32_t)
-		    (size-of-int64 size-of-int64_t))
+            ;; pointer set
+            pointer-set-c-uint8!
+            pointer-set-c-int8!
+            pointer-set-c-uint16!
+            pointer-set-c-int16!
+            pointer-set-c-uint32!
+            pointer-set-c-int32!
+            pointer-set-c-uint64!
+            pointer-set-c-int64!
+            pointer-set-c-unsigned-char!
+            pointer-set-c-char!
+            pointer-set-c-unsigned-short!
+            pointer-set-c-short!
+            pointer-set-c-unsigned-int!
+            pointer-set-c-int!
+            pointer-set-c-unsigned-long!
+            pointer-set-c-long!
+            pointer-set-c-float!
+            pointer-set-c-double!
+            pointer-set-c-pointer!
 
-	    pointer?
-	    bytevector->pointer
-	    pointer->bytevector
-	    pointer->integer
-	    integer->pointer
-	    )
+            ;; sizeof
+            size-of-char
+            size-of-short
+            size-of-int
+            size-of-long
+            size-of-float
+            size-of-double
+            size-of-pointer
+            (rename (size-of-int8 size-of-int8_t)
+                    (size-of-int16 size-of-int16_t)
+                    (size-of-int32 size-of-int32_t)
+                    (size-of-int64 size-of-int64_t))
+
+            pointer?
+            bytevector->pointer
+            pointer->bytevector
+            pointer->integer
+            integer->pointer
+            )
     (import (rnrs)
-	    (rename (pffi bv-pointer)
-		    (bytevector->pointer bytevector->address))
-	    (only (chezscheme)
-		  load-shared-object
-		  lock-object foreign-callable-entry-point
-		  foreign-callable unlock-object
-		  foreign-procedure
-		  ftype-pointer-address
-		  foreign-entry foreign-sizeof foreign-ref foreign-set!))
+            (rename (pffi bv-pointer)
+                    (bytevector->pointer bytevector->address))
+            (only (chezscheme)
+                  load-shared-object
+                  lock-object foreign-callable-entry-point
+                  foreign-callable unlock-object
+                  foreign-procedure
+                  ftype-pointer-address
+                  foreign-entry foreign-sizeof foreign-ref foreign-set!))
 
 ;; dummy value
 (define-record-type shared-object)
@@ -136,7 +136,7 @@
   ;; FIXME one way copy
   (let ((bv (make-bytevector len)))
     (do ((i 0 (+ i 1)))
-	((= i len) bv)
+        ((= i len) bv)
       (bytevector-u8-set! bv i (pointer-ref-c-uint8 pointer i)))))
 (define (bytevector->pointer bv) (make-pointer (bytevector->address bv)))
 
@@ -176,147 +176,147 @@
   (lambda (x)
     (define (->cheztype type)
       (case type
-	((void          ) 'void)
-	((char          ) 'integer-8)
-	((unsigned-char ) 'unsigned-8)
-	((short         ) 'short)
-	((unsigned-short) 'unsigned-short)
-	((int           ) 'int)
-	((unsigned-int  ) 'unsigned-int)
-	((long          ) 'long)
-	((unsigned-long ) 'unsigned-long)
-	((int8_t        ) 'integer-8)
-	((uint8_t       ) 'unsigned-8)
-	((int16_t       ) 'integer-16)
-	((uint16_t      ) 'unsigned-16)
-	((int32_t       ) 'integer-32)
-	((uint32_t      ) 'unsigned-32)
-	((int64_t       ) 'integer-64)
-	((uint64_t      ) 'unsigned-64)
-	((double        ) 'double)
-	((float         ) 'float)
-	((pointer       ) 'void*)
-	;; let chez complain
-	(else type)))
+        ((void          ) 'void)
+        ((char          ) 'integer-8)
+        ((unsigned-char ) 'unsigned-8)
+        ((short         ) 'short)
+        ((unsigned-short) 'unsigned-short)
+        ((int           ) 'int)
+        ((unsigned-int  ) 'unsigned-int)
+        ((long          ) 'long)
+        ((unsigned-long ) 'unsigned-long)
+        ((int8_t        ) 'integer-8)
+        ((uint8_t       ) 'unsigned-8)
+        ((int16_t       ) 'integer-16)
+        ((uint16_t      ) 'unsigned-16)
+        ((int32_t       ) 'integer-32)
+        ((uint32_t      ) 'unsigned-32)
+        ((int64_t       ) 'integer-64)
+        ((uint64_t      ) 'unsigned-64)
+        ((double        ) 'double)
+        ((float         ) 'float)
+        ((pointer       ) 'void*)
+        ;; let chez complain
+        (else type)))
     (define (unwrap-callback k args)
       (define (types args acc)
-	(syntax-case args ()
-	  (() (reverse acc))
-	  (((type ignore ...) rest ...)
-	   (and (identifier? #'type) (eq? 'callback (syntax->datum #'type)))
-	   (types #'(rest ...) (cons 'void* acc)))
-	  ((type rest ...)
-	   (types #'(rest ...)
-		  (cons (->cheztype (syntax->datum #'type)) acc)))))
+        (syntax-case args ()
+          (() (reverse acc))
+          (((type ignore ...) rest ...)
+           (and (identifier? #'type) (eq? 'callback (syntax->datum #'type)))
+           (types #'(rest ...) (cons 'void* acc)))
+          ((type rest ...)
+           (types #'(rest ...)
+                  (cons (->cheztype (syntax->datum #'type)) acc)))))
       (datum->syntax k (types args '())))
 
     (syntax-case x (quote list)
       ((k lib ret (quote name) (list args ...))
        (identifier? #'name)
        (with-syntax ((name-str (symbol->string (syntax->datum #'name)))
-		     ((types ...) (unwrap-callback #'k #'(args ...)))
-		     (chez-ret (datum->syntax #'k
-				(->cheztype (syntax->datum #'ret)))))
-	 #'(let ((fp (foreign-procedure name-str (types ...) chez-ret))
-		 (arg-types (list args ...)))
-	     (define (b->p b) (pointer->integer (bytevector->pointer b)))
-	     (define (s->p s)
-	       (b->p (string->utf8 (string-append s "\x0;"))))
-	     (lambda arg*
-	       (let ((r (apply fp
-			       (map (lambda (type arg)
-				      (case type
-					((void*)
-					 (cond ((string? arg) (s->p arg))
-					       ((bytevector? arg) (b->p arg))
-					       (else (pointer->integer arg))))
-					(else arg)))
-				    arg-types arg*))))
-		 (case ret
-		   ((void*) (integer->pointer r))
-		   (else r))))))))))
+                     ((types ...) (unwrap-callback #'k #'(args ...)))
+                     (chez-ret (datum->syntax #'k
+                                (->cheztype (syntax->datum #'ret)))))
+         #'(let ((fp (foreign-procedure name-str (types ...) chez-ret))
+                 (arg-types (list args ...)))
+             (define (b->p b) (pointer->integer (bytevector->pointer b)))
+             (define (s->p s)
+               (b->p (string->utf8 (string-append s "\x0;"))))
+             (lambda arg*
+               (let ((r (apply fp
+                               (map (lambda (type arg)
+                                      (case type
+                                        ((void*)
+                                         (cond ((string? arg) (s->p arg))
+                                               ((bytevector? arg) (b->p arg))
+                                               (else (pointer->integer arg))))
+                                        (else arg)))
+                                    arg-types arg*))))
+                 (case ret
+                   ((void*) (integer->pointer r))
+                   (else r))))))))))
 (define-syntax make-c-callback
   (lambda (x)
     (define (->cheztype type)
       (case type
-	((void          ) 'void)
-	((char          ) 'integer-8)
-	((unsigned-char ) 'unsigned-8)
-	((short         ) 'short)
-	((unsigned-short) 'unsigned-short)
-	((int           ) 'int)
-	((unsigned-int  ) 'unsigned-int)
-	((long          ) 'long)
-	((unsigned-long ) 'unsigned-long)
-	((int8_t        ) 'integer-8)
-	((uint8_t       ) 'unsigned-8)
-	((int16_t       ) 'integer-16)
-	((uint16_t      ) 'unsigned-16)
-	((int32_t       ) 'integer-32)
-	((uint32_t      ) 'unsigned-32)
-	((int64_t       ) 'integer-64)
-	((uint64_t      ) 'unsigned-64)
-	((double        ) 'double)
-	((float         ) 'float)
-	((pointer       ) 'void*)
-	;; let chez complain
-	(else type)))
+        ((void          ) 'void)
+        ((char          ) 'integer-8)
+        ((unsigned-char ) 'unsigned-8)
+        ((short         ) 'short)
+        ((unsigned-short) 'unsigned-short)
+        ((int           ) 'int)
+        ((unsigned-int  ) 'unsigned-int)
+        ((long          ) 'long)
+        ((unsigned-long ) 'unsigned-long)
+        ((int8_t        ) 'integer-8)
+        ((uint8_t       ) 'unsigned-8)
+        ((int16_t       ) 'integer-16)
+        ((uint16_t      ) 'unsigned-16)
+        ((int32_t       ) 'integer-32)
+        ((uint32_t      ) 'unsigned-32)
+        ((int64_t       ) 'integer-64)
+        ((uint64_t      ) 'unsigned-64)
+        ((double        ) 'double)
+        ((float         ) 'float)
+        ((pointer       ) 'void*)
+        ;; let chez complain
+        (else type)))
     (define (unwrap-callback k args)
       (define (types args acc)
-	(syntax-case args ()
-	  (() (reverse acc))
-	  (((type ignore ...) rest ...)
-	   (and (identifier? #'type) (eq? 'callback (syntax->datum #'type)))
-	   (types #'(rest ...) (cons 'void* acc)))
-	  ((type rest ...)
-	   (types #'(rest ...)
-		  (cons (->cheztype (syntax->datum #'type)) acc)))))
+        (syntax-case args ()
+          (() (reverse acc))
+          (((type ignore ...) rest ...)
+           (and (identifier? #'type) (eq? 'callback (syntax->datum #'type)))
+           (types #'(rest ...) (cons 'void* acc)))
+          ((type rest ...)
+           (types #'(rest ...)
+                  (cons (->cheztype (syntax->datum #'type)) acc)))))
       (datum->syntax k (types args '())))
     (syntax-case x (list)
       ((k ret (list arg* ...) body)
        (with-syntax (((types ...) (unwrap-callback #'k #'(arg* ...)))
-		     (chez-ret (datum->syntax #'k (->cheztype (syntax->datum #'ret)))))
-	 #'(let ((args (list arg* ...)))
-	     (define (wrap proc)
-	       (lambda vals
-		 (let ((r (apply proc (map (lambda (type arg)
-					     (case type
-					       ((void*) (integer->pointer arg))
-					       (else arg)))
-					   args vals))))
-		   (if (pointer? r)
-		       (pointer->integer r)
-		       r))))
-	     (let ((p (wrap body)))
-	       (define code (foreign-callable p (types ...) chez-ret))
-	       (lock-object code)
-	       (foreign-callable-entry-point code))))))))
+                     (chez-ret (datum->syntax #'k (->cheztype (syntax->datum #'ret)))))
+         #'(let ((args (list arg* ...)))
+             (define (wrap proc)
+               (lambda vals
+                 (let ((r (apply proc (map (lambda (type arg)
+                                             (case type
+                                               ((void*) (integer->pointer arg))
+                                               (else arg)))
+                                           args vals))))
+                   (if (pointer? r)
+                       (pointer->integer r)
+                       r))))
+             (let ((p (wrap body)))
+               (define code (foreign-callable p (types ...) chez-ret))
+               (lock-object code)
+               (foreign-callable-entry-point code))))))))
 
 (define-syntax define-deref
   (lambda (x)
     (define (gen-name t)
       (let ((s (symbol->string (syntax->datum t))))
-	(list (string->symbol (string-append "size-of-" s))
-	      (string->symbol (string-append "pointer-ref-c-" s))
-	      (string->symbol (string-append "pointer-set-c-" s "!")))))
+        (list (string->symbol (string-append "size-of-" s))
+              (string->symbol (string-append "pointer-ref-c-" s))
+              (string->symbol (string-append "pointer-set-c-" s "!")))))
     (syntax-case x ()
       ((k type)
        (with-syntax (((size ref set!) (datum->syntax #'k (gen-name #'type))))
-	 #'(begin
-	     (define size (foreign-sizeof type))
-	     (define (ref ptr offset)
-	       (foreign-ref type (pointer->integer ptr) offset))
-	     (define (set! ptr offset value)
-	       (foreign-set! type (pointer->integer ptr) offset value)))))
+         #'(begin
+             (define size (foreign-sizeof type))
+             (define (ref ptr offset)
+               (foreign-ref type (pointer->integer ptr) offset))
+             (define (set! ptr offset value)
+               (foreign-set! type (pointer->integer ptr) offset value)))))
       ((k type conv unwrap)
        (with-syntax (((size ref set!) (datum->syntax #'k (gen-name #'type))))
-	 #'(begin
-	     (define size (foreign-sizeof type))
-	     (define (ref ptr offset)
-	       (conv (foreign-ref type (pointer->integer ptr) offset)))
-	     (define (set! ptr offset value)
-	       (foreign-set! type (pointer->integer ptr) offset
-			     (unwrap value)))))))))
+         #'(begin
+             (define size (foreign-sizeof type))
+             (define (ref ptr offset)
+               (conv (foreign-ref type (pointer->integer ptr) offset)))
+             (define (set! ptr offset value)
+               (foreign-set! type (pointer->integer ptr) offset
+                             (unwrap value)))))))))
 
 (define int8    int8_t)
 (define uint8  uint8_t)

--- a/src/pffi/compat.guile.sls
+++ b/src/pffi/compat.guile.sls
@@ -1,20 +1,20 @@
 ;;; -*- mode:scheme; coding: utf-8; -*-
 ;;;
 ;;; src/pffi/compat.guile.sls - Compatible layer for Guile
-;;;  
+;;;
 ;;;   Copyright (c) 2015  Takashi Kato  <ktakashi@ymail.com>
-;;;   
+;;;
 ;;;   Redistribution and use in source and binary forms, with or without
 ;;;   modification, are permitted provided that the following conditions
 ;;;   are met:
-;;;   
+;;;
 ;;;   1. Redistributions of source code must retain the above copyright
 ;;;      notice, this list of conditions and the following disclaimer.
-;;;  
+;;;
 ;;;   2. Redistributions in binary form must reproduce the above copyright
 ;;;      notice, this list of conditions and the following disclaimer in the
 ;;;      documentation and/or other materials provided with the distribution.
-;;;  
+;;;
 ;;;   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
 ;;;   "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
 ;;;   LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
@@ -26,7 +26,7 @@
 ;;;   LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
 ;;;   NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 ;;;   SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-;;;  
+;;;
 
 ;; this file provides compatible layer for (pffi procedure)
 ;; if implementations can't make this layer, then make
@@ -36,89 +36,89 @@
 #!r6rs
 (library (pffi compat)
     (export open-shared-object
-	    lookup-shared-object
-	    make-c-function
-	    make-c-callback
-	    free-c-callback
+            lookup-shared-object
+            make-c-function
+            make-c-callback
+            free-c-callback
 
-	    ;; primitive types
-	    char  unsigned-char
-	    short unsigned-short
-	    int   unsigned-int
-	    long  unsigned-long
-	    float double
-	    int8_t  uint8_t
-	    int16_t uint16_t
-	    int32_t uint32_t
-	    int64_t uint64_t
-	    pointer callback
-	    void
+            ;; primitive types
+            char  unsigned-char
+            short unsigned-short
+            int   unsigned-int
+            long  unsigned-long
+            float double
+            int8_t  uint8_t
+            int16_t uint16_t
+            int32_t uint32_t
+            int64_t uint64_t
+            pointer callback
+            void
 
-	    ;; pointer ref
-	    pointer-ref-c-uint8
-	    pointer-ref-c-int8
-	    pointer-ref-c-uint16
-	    pointer-ref-c-int16
-	    pointer-ref-c-uint32
-	    pointer-ref-c-int32
-	    pointer-ref-c-uint64
-	    pointer-ref-c-int64
-	    pointer-ref-c-unsigned-char
-	    pointer-ref-c-char
-	    pointer-ref-c-unsigned-short
-	    pointer-ref-c-short
-	    pointer-ref-c-unsigned-int
-	    pointer-ref-c-int
-	    pointer-ref-c-unsigned-long
-	    pointer-ref-c-long
-	    pointer-ref-c-float
-	    pointer-ref-c-double
-	    pointer-ref-c-pointer
+            ;; pointer ref
+            pointer-ref-c-uint8
+            pointer-ref-c-int8
+            pointer-ref-c-uint16
+            pointer-ref-c-int16
+            pointer-ref-c-uint32
+            pointer-ref-c-int32
+            pointer-ref-c-uint64
+            pointer-ref-c-int64
+            pointer-ref-c-unsigned-char
+            pointer-ref-c-char
+            pointer-ref-c-unsigned-short
+            pointer-ref-c-short
+            pointer-ref-c-unsigned-int
+            pointer-ref-c-int
+            pointer-ref-c-unsigned-long
+            pointer-ref-c-long
+            pointer-ref-c-float
+            pointer-ref-c-double
+            pointer-ref-c-pointer
 
-	    ;; pointer set
-	    pointer-set-c-uint8!
-	    pointer-set-c-int8!
-	    pointer-set-c-uint16!
-	    pointer-set-c-int16!
-	    pointer-set-c-uint32!
-	    pointer-set-c-int32!
-	    pointer-set-c-uint64!
-	    pointer-set-c-int64!
-	    pointer-set-c-unsigned-char!
-	    pointer-set-c-char!
-	    pointer-set-c-unsigned-short!
-	    pointer-set-c-short!
-	    pointer-set-c-unsigned-int!
-	    pointer-set-c-int!
-	    pointer-set-c-unsigned-long!
-	    pointer-set-c-long!
-	    pointer-set-c-float!
-	    pointer-set-c-double!
-	    pointer-set-c-pointer!
-	    
-	    ;; sizeof
-	    size-of-char
-	    size-of-short
-	    size-of-int
-	    size-of-long
-	    size-of-float
-	    size-of-double
-	    size-of-pointer
-	    size-of-int8_t
-	    size-of-int16_t
-	    size-of-int32_t
-	    size-of-int64_t
+            ;; pointer set
+            pointer-set-c-uint8!
+            pointer-set-c-int8!
+            pointer-set-c-uint16!
+            pointer-set-c-int16!
+            pointer-set-c-uint32!
+            pointer-set-c-int32!
+            pointer-set-c-uint64!
+            pointer-set-c-int64!
+            pointer-set-c-unsigned-char!
+            pointer-set-c-char!
+            pointer-set-c-unsigned-short!
+            pointer-set-c-short!
+            pointer-set-c-unsigned-int!
+            pointer-set-c-int!
+            pointer-set-c-unsigned-long!
+            pointer-set-c-long!
+            pointer-set-c-float!
+            pointer-set-c-double!
+            pointer-set-c-pointer!
 
-	    pointer?
-	    bytevector->pointer
-	    pointer->bytevector
-	    (rename (pointer-address pointer->integer)
-		    (make-pointer integer->pointer))
-	    )
+            ;; sizeof
+            size-of-char
+            size-of-short
+            size-of-int
+            size-of-long
+            size-of-float
+            size-of-double
+            size-of-pointer
+            size-of-int8_t
+            size-of-int16_t
+            size-of-int32_t
+            size-of-int64_t
+
+            pointer?
+            bytevector->pointer
+            pointer->bytevector
+            (rename (pointer-address pointer->integer)
+                    (make-pointer integer->pointer))
+            )
     (import (rnrs)
-	    (only (guile) dynamic-link dynamic-pointer)
-	    (system foreign)
-	    (only (srfi :13) string-index-right))
+            (only (guile) dynamic-link dynamic-pointer)
+            (system foreign)
+            (only (srfi :13) string-index-right))
 
 (define-syntax callback
   (syntax-rules ()
@@ -139,9 +139,9 @@
 
 (define (open-shared-object path)
   (let* ((index (string-index-right path #\.))
-	 (file (if index
-		   (substring path 0 index)
-		   path)))
+         (file (if index
+                   (substring path 0 index)
+                   path)))
     (dynamic-link file)))
 (define (lookup-shared-object lib name)
   (dynamic-pointer name lib))
@@ -150,7 +150,7 @@
 
 (define (make-c-function lib ret name arg-types)
   (pointer->procedure ret (lookup-shared-object lib (symbol->string name))
-		      arg-types))
+                      arg-types))
 
 (define (make-c-callback ret args proc)
   (procedure->pointer ret proc args))
@@ -159,19 +159,19 @@
   (lambda (x)
     (define (gen-name t)
       (let ((s (symbol->string (syntax->datum t))))
-	(list (string->symbol (string-append "size-of-" s))
-	      (string->symbol (string-append "pointer-ref-c-" s))
-	      (string->symbol (string-append "pointer-set-c-" s "!")))))
+        (list (string->symbol (string-append "size-of-" s))
+              (string->symbol (string-append "pointer-ref-c-" s))
+              (string->symbol (string-append "pointer-set-c-" s "!")))))
     (syntax-case x ()
       ((k type bv-ref bv-set!)
        (with-syntax (((size ref set!) (datum->syntax #'k (gen-name #'type))))
-	 #'(begin
-	     (define (ref ptr offset)
-	       (let ((bv (pointer->bytevector ptr (+ size offset))))
-		 (bv-ref bv offset (native-endianness))))
-	     (define (set! ptr offset value)
-	       (let ((bv (pointer->bytevector ptr (+ size offset))))
-		 (bv-set! bv offset value (native-endianness))))))))))
+         #'(begin
+             (define (ref ptr offset)
+               (let ((bv (pointer->bytevector ptr (+ size offset))))
+                 (bv-ref bv offset (native-endianness))))
+             (define (set! ptr offset value)
+               (let ((bv (pointer->bytevector ptr (+ size offset))))
+                 (bv-set! bv offset value (native-endianness))))))))))
 (define (bytevector-u8-ref/endian bv index endian)
   (bytevector-u8-ref bv index))
 (define (bytevector-u8-set/endian! bv index v endian)
@@ -227,8 +227,8 @@
 (define (bytevector-pointer-set! bv index v endian)
   (let ((i (pointer-address v)))
     (if (= size-of-pointer 4)
-	(bytevector-u32-set! bv index i endian)
-	(bytevector-u64-set! bv index i endian))))
+        (bytevector-u32-set! bv index i endian)
+        (bytevector-u64-set! bv index i endian))))
 (define-deref pointer bytevector-pointer-ref bytevector-pointer-set!)
 
 
@@ -236,11 +236,11 @@
   (lambda (x)
     (define (gen-name t)
       (let ((s (symbol->string (syntax->datum t))))
-	(string->symbol (string-append "size-of-" s))))
+        (string->symbol (string-append "size-of-" s))))
     (syntax-case x ()
       ((k type)
        (with-syntax ((name (datum->syntax #'k (gen-name #'type))))
-	 #'(define name (sizeof type)))))))
+         #'(define name (sizeof type)))))))
 
 (define-sizeof char)
 (define-sizeof short)

--- a/src/pffi/compat.larceny.sls
+++ b/src/pffi/compat.larceny.sls
@@ -1,20 +1,20 @@
 ;;; -*- mode:scheme; coding: utf-8; -*-
 ;;;
 ;;; src/pffi/compat.larceny.sls - Compatible layer for Larceny
-;;;  
+;;;
 ;;;   Copyright (c) 2015-2018 Takashi Kato  <ktakashi@ymail.com>
-;;;   
+;;;
 ;;;   Redistribution and use in source and binary forms, with or without
 ;;;   modification, are permitted provided that the following conditions
 ;;;   are met:
-;;;   
+;;;
 ;;;   1. Redistributions of source code must retain the above copyright
 ;;;      notice, this list of conditions and the following disclaimer.
-;;;  
+;;;
 ;;;   2. Redistributions in binary form must reproduce the above copyright
 ;;;      notice, this list of conditions and the following disclaimer in the
 ;;;      documentation and/or other materials provided with the distribution.
-;;;  
+;;;
 ;;;   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
 ;;;   "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
 ;;;   LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
@@ -26,7 +26,7 @@
 ;;;   LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
 ;;;   NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 ;;;   SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-;;;  
+;;;
 
 ;; this file provides compatible layer for (pffi procedure)
 ;; if implementations can't make this layer, then make
@@ -36,142 +36,142 @@
 #!r6rs
 (library (pffi compat)
     (export open-shared-object
-	    lookup-shared-object
+            lookup-shared-object
 
-	    make-c-function
-	    make-c-callback
-	    free-c-callback
+            make-c-function
+            make-c-callback
+            free-c-callback
 
 
-	    ;; primitive types
-	    char  unsigned-char
-	    short unsigned-short
-	    int   unsigned-int
-	    long  unsigned-long
-	    float double
-	    int8_t  uint8_t
-	    int16_t uint16_t
-	    int32_t uint32_t
-	    int64_t uint64_t
-	    pointer callback
-	    void
-	    ;; pointer ref
-	    pointer-ref-c-uint8
-	    pointer-ref-c-int8
-	    pointer-ref-c-uint16
-	    pointer-ref-c-int16
-	    pointer-ref-c-uint32
-	    pointer-ref-c-int32
-	    pointer-ref-c-uint64
-	    pointer-ref-c-int64
-	    pointer-ref-c-unsigned-char
-	    pointer-ref-c-char
-	    pointer-ref-c-unsigned-short
-	    pointer-ref-c-short
-	    pointer-ref-c-unsigned-int
-	    pointer-ref-c-int
-	    pointer-ref-c-unsigned-long
-	    pointer-ref-c-long
-	    pointer-ref-c-float
-	    pointer-ref-c-double
-	    pointer-ref-c-pointer
+            ;; primitive types
+            char  unsigned-char
+            short unsigned-short
+            int   unsigned-int
+            long  unsigned-long
+            float double
+            int8_t  uint8_t
+            int16_t uint16_t
+            int32_t uint32_t
+            int64_t uint64_t
+            pointer callback
+            void
+            ;; pointer ref
+            pointer-ref-c-uint8
+            pointer-ref-c-int8
+            pointer-ref-c-uint16
+            pointer-ref-c-int16
+            pointer-ref-c-uint32
+            pointer-ref-c-int32
+            pointer-ref-c-uint64
+            pointer-ref-c-int64
+            pointer-ref-c-unsigned-char
+            pointer-ref-c-char
+            pointer-ref-c-unsigned-short
+            pointer-ref-c-short
+            pointer-ref-c-unsigned-int
+            pointer-ref-c-int
+            pointer-ref-c-unsigned-long
+            pointer-ref-c-long
+            pointer-ref-c-float
+            pointer-ref-c-double
+            pointer-ref-c-pointer
 
-	    ;; pointer set
-	    pointer-set-c-uint8!
-	    pointer-set-c-int8!
-	    pointer-set-c-uint16!
-	    pointer-set-c-int16!
-	    pointer-set-c-uint32!
-	    pointer-set-c-int32!
-	    pointer-set-c-uint64!
-	    pointer-set-c-int64!
-	    pointer-set-c-unsigned-char!
-	    pointer-set-c-char!
-	    pointer-set-c-unsigned-short!
-	    pointer-set-c-short!
-	    pointer-set-c-unsigned-int!
-	    pointer-set-c-int!
-	    pointer-set-c-unsigned-long!
-	    pointer-set-c-long!
-	    pointer-set-c-float!
-	    pointer-set-c-double!
-	    pointer-set-c-pointer!
+            ;; pointer set
+            pointer-set-c-uint8!
+            pointer-set-c-int8!
+            pointer-set-c-uint16!
+            pointer-set-c-int16!
+            pointer-set-c-uint32!
+            pointer-set-c-int32!
+            pointer-set-c-uint64!
+            pointer-set-c-int64!
+            pointer-set-c-unsigned-char!
+            pointer-set-c-char!
+            pointer-set-c-unsigned-short!
+            pointer-set-c-short!
+            pointer-set-c-unsigned-int!
+            pointer-set-c-int!
+            pointer-set-c-unsigned-long!
+            pointer-set-c-long!
+            pointer-set-c-float!
+            pointer-set-c-double!
+            pointer-set-c-pointer!
 
-	    ;; sizeof
-	    size-of-char
-	    size-of-short
-	    size-of-int
-	    size-of-long
-	    size-of-float
-	    size-of-double
-	    size-of-pointer
-	    size-of-int8_t
-	    size-of-int16_t
-	    size-of-int32_t
-	    size-of-int64_t
+            ;; sizeof
+            size-of-char
+            size-of-short
+            size-of-int
+            size-of-long
+            size-of-float
+            size-of-double
+            size-of-pointer
+            size-of-int8_t
+            size-of-int16_t
+            size-of-int32_t
+            size-of-int64_t
 
-	    pointer?
-	    bytevector->pointer
-	    pointer->bytevector
-	    pointer->integer
-	    integer->pointer
+            pointer?
+            bytevector->pointer
+            pointer->bytevector
+            pointer->integer
+            integer->pointer
 
-	    )
+            )
     (import (rnrs)
-	    (primitives ffi/dlopen ffi/dlsym
-			ffi-attribute-core-entry
-			ffi/ret-converter
-			ffi/arg-converter
-			ffi/convert-arg-descriptor
-			ffi/convert-ret-descriptor
-			ffi/make-callout
-			ffi/make-callback
-			ffi/apply
-			;; in lib/Base/std-ffi.sch
-			ffi-get-abi
-			ffi/rename-ret-type
-			ffi/rename-arg-type
-			void*-rt
-			void*?
-			void*->address
-			sizeof:long
-			sizeof:pointer
-			%peek8 %peek8u
-			%peek16 %peek16u
-			%peek32 %peek32u
-			%peek-long %peek-ulong
-			peek-bytes
-			poke-bytes
-			void*-float-ref
-			void*-double-ref
-			void*-void*-ref
-			void*-void*-set!
-			ffi/handle->address
-			make-nonrelocatable-bytevector
-			))
+            (primitives ffi/dlopen ffi/dlsym
+                        ffi-attribute-core-entry
+                        ffi/ret-converter
+                        ffi/arg-converter
+                        ffi/convert-arg-descriptor
+                        ffi/convert-ret-descriptor
+                        ffi/make-callout
+                        ffi/make-callback
+                        ffi/apply
+                        ;; in lib/Base/std-ffi.sch
+                        ffi-get-abi
+                        ffi/rename-ret-type
+                        ffi/rename-arg-type
+                        void*-rt
+                        void*?
+                        void*->address
+                        sizeof:long
+                        sizeof:pointer
+                        %peek8 %peek8u
+                        %peek16 %peek16u
+                        %peek32 %peek32u
+                        %peek-long %peek-ulong
+                        peek-bytes
+                        poke-bytes
+                        void*-float-ref
+                        void*-double-ref
+                        void*-void*-ref
+                        void*-void*-set!
+                        ffi/handle->address
+                        make-nonrelocatable-bytevector
+                        ))
 
 ;; it might be better not to show handle (integer) itself
 (define-record-type shared-object
   (fields handle))
 
-(define (open-shared-object path) 
+(define (open-shared-object path)
   (let ((handle (ffi/dlopen path)))
     (and handle
-	 (make-shared-object handle))))
+         (make-shared-object handle))))
 
 (define-record-type (<pointer> make-pointer pointer?)
   (fields (immutable src pointer-src)
-	  ;; nonrelocatable bytevector 
-	  dummy
-	  ;; element pointer of above
-	  (immutable ptr pointer-ptr)))
+          ;; nonrelocatable bytevector
+          dummy
+          ;; element pointer of above
+          (immutable ptr pointer-ptr)))
 (define (null-pointer? pointer) (zero? (pointer->integer pointer)))
 
 (define (void*->pointer v*)
   (let ((bv (make-bytevector size-of-pointer)))
     (if (= size-of-pointer 4)
-	(bytevector-u32-native-set! bv 0 (void*-ptr v*))
-	(bytevector-u64-native-set! bv 0 (void*-ptr v*)))
+        (bytevector-u32-native-set! bv 0 (void*-ptr v*))
+        (bytevector-u64-native-set! bv 0 (void*-ptr v*)))
     (make-pointer bv #f v*)))
 
 ;; we can't use unsigned->void*, this converts null pointer
@@ -182,7 +182,7 @@
     (void*->pointer (make-void* addr))))
 ;; ffi/dlsym returns integer (address) directly so
 ;; we need to get converter
-(define (lookup-shared-object lib name) 
+(define (lookup-shared-object lib name)
   (let ((address (ffi/dlsym (shared-object-handle lib) name)))
     (address->pointer address)))
 
@@ -191,9 +191,9 @@
 (define (pointer->void* t o)
   (define (convert o)
     (cond ((pointer? o) (pointer-ptr o))
-	  ((bytevector? o) (convert (bytevector->pointer o)))
-	  ((string? o) (convert (string->utf8 (string-append o "\x0;"))))
-	  (else o)))
+          ((bytevector? o) (convert (bytevector->pointer o)))
+          ((string? o) (convert (string->utf8 (string-append o "\x0;"))))
+          (else o)))
   (case t
     ((void*) (convert o))
     (else o)))
@@ -205,58 +205,58 @@
 (define (sync-pointer arg)
   (if (and (pointer? arg) (not (null-pointer? arg)))
       (let* ((dst (pointer-src arg))
-	     (len (bytevector-length dst)))
-	(do ((i 0 (+ i 1)))
-	    ((= i len) arg)
-	  (bytevector-u8-set! dst i (pointer-ref-c-uint8 arg i))))
+             (len (bytevector-length dst)))
+        (do ((i 0 (+ i 1)))
+            ((= i len) arg)
+          (bytevector-u8-set! dst i (pointer-ref-c-uint8 arg i))))
       arg))
 
 (define (make-foreign-invoker tramp args ret ret-conv arg-conv name arg-types)
   (lambda actual
     ;; (display name) (newline) (display actual) (newline)
-    (let-values (((error? value) 
-		  (ffi/apply tramp args ret 
-			     (map (lambda (c v) (c v (symbol->string name)))
-				  arg-conv
-				  (map pointer->void* arg-types actual)))))
+    (let-values (((error? value)
+                  (ffi/apply tramp args ret
+                             (map (lambda (c v) (c v (symbol->string name)))
+                                  arg-conv
+                                  (map pointer->void* arg-types actual)))))
       (for-each sync-pointer actual)
       (if error?
-	  (error name "Failed to call foreign procedure" name actual)
-	  (sync-pointer (%void*->pointer (ret-conv value (symbol->string name))))))))
+          (error name "Failed to call foreign procedure" name actual)
+          (sync-pointer (%void*->pointer (ret-conv value (symbol->string name))))))))
 
-(define make-c-function 
+(define make-c-function
   ;; for some reason ffi-get-abi requires something for type
   ;; and if we pass null, we can get cdecl
   (let ((abi (ffi-get-abi 'callout '())))
     (lambda (lib ret name arg-type)
       (let* ((rconv (ffi/ret-converter ret))
-	     (argconv (map ffi/arg-converter arg-type))
-	     (addr (ffi/dlsym (shared-object-handle lib) (symbol->string name)))
-	     (renamed-args (map ffi/rename-arg-type arg-type))
-	     (renamed-ret (ffi/rename-ret-type ret))
-	     (tramp (ffi/make-callout abi addr renamed-args renamed-ret))
-	     (args (ffi/convert-arg-descriptor abi renamed-args))
-	     (ret (ffi/convert-ret-descriptor abi renamed-ret)))
-	(make-foreign-invoker tramp args ret rconv argconv name arg-type)))))
+             (argconv (map ffi/arg-converter arg-type))
+             (addr (ffi/dlsym (shared-object-handle lib) (symbol->string name)))
+             (renamed-args (map ffi/rename-arg-type arg-type))
+             (renamed-ret (ffi/rename-ret-type ret))
+             (tramp (ffi/make-callout abi addr renamed-args renamed-ret))
+             (args (ffi/convert-arg-descriptor abi renamed-args))
+             (ret (ffi/convert-ret-descriptor abi renamed-ret)))
+        (make-foreign-invoker tramp args ret rconv argconv name arg-type)))))
 
 ;; maybe we should make this GC protected
 (define make-c-callback
   (let ((abi (ffi-get-abi 'callback '())))
     (lambda (ret types proc)
-      (ffi/make-callback 
+      (ffi/make-callback
        abi
        (lambda args
-	 (let ((v (apply proc (map (lambda (t v)
-				     (sync-pointer
-				      (%void*->pointer ((ffi/ret-converter t) v t))))
-				   types args)))
-	       (r-conv (ffi/arg-converter ret)))
-	   ;; sync returning value 
-	   (pointer->void*
-	    (sync-pointer
-	     (if r-conv
-		 (r-conv v ret)
-		 v)))))
+         (let ((v (apply proc (map (lambda (t v)
+                                     (sync-pointer
+                                      (%void*->pointer ((ffi/ret-converter t) v t))))
+                                   types args)))
+               (r-conv (ffi/arg-converter ret)))
+           ;; sync returning value
+           (pointer->void*
+            (sync-pointer
+             (if r-conv
+                 (r-conv v ret)
+                 v)))))
        (map ffi/rename-arg-type types)
        (ffi/rename-ret-type ret)))))
 ;; dummy
@@ -280,12 +280,12 @@
 (define-pointer-ref pointer-ref-c-int32 %peek32)
 (define (pointer-ref-c-uint64 p offset)
   (let* ((addr (pointer-pointer p))
-	 (bv (make-bytevector 8)))
+         (bv (make-bytevector 8)))
     (peek-bytes (+ addr offset) bv 8)
     (bytevector-u64-native-ref bv 0)))
 (define (pointer-ref-c-int64 p offset)
   (let* ((addr (pointer-pointer p))
-	 (bv (make-bytevector 8)))
+         (bv (make-bytevector 8)))
     (peek-bytes (+ addr offset) bv 8)
     (bytevector-s64-native-ref bv 0)))
 
@@ -314,8 +314,8 @@
     ((_ name size bv-set)
      (define (name p offset val)
        (let ((bv (make-bytevector size)))
-	 (bv-set bv 0 val)
-	 (poke-bytes (+ (pointer-pointer p) offset) bv size))))))
+         (bv-set bv 0 val)
+         (poke-bytes (+ (pointer-pointer p) offset) bv size))))))
 
 (define (bytevector-long-native-set! bv index val)
   (if (= size-of-long 4)
@@ -340,15 +340,15 @@
 (define pointer-set-c-short! pointer-set-c-int16!)
 (define pointer-set-c-unsigned-int! pointer-set-c-uint32!)
 (define pointer-set-c-int! pointer-set-c-int32!)
-(define-pointer-set pointer-set-c-unsigned-long! 
+(define-pointer-set pointer-set-c-unsigned-long!
   size-of-long bytevector-ulong-native-set!)
-(define-pointer-set pointer-set-c-long! 
+(define-pointer-set pointer-set-c-long!
   size-of-long bytevector-long-native-set!)
 (define-pointer-set pointer-set-c-float! 4 bytevector-ieee-single-native-set!)
 (define-pointer-set pointer-set-c-double! 8 bytevector-ieee-double-native-set!)
 (define (pointer-set-c-pointer! p offset v)
   (let ((p (pointer-ptr p))
-	(v (pointer-ptr v)))
+        (v (pointer-ptr v)))
     (void*-void*-set! p offset v)))
 
 
@@ -403,11 +403,11 @@
   ;; Unfortunately, we only have one way, copy
   (let ((bv (make-bytevector len)))
     (do ((i 0 (+ i 1)))
-	((= i len) bv)
+        ((= i len) bv)
       (bytevector-u8-set! bv i (pointer-ref-c-uint8 p i)))))
 
 (define integer->pointer address->pointer)
 (define (pointer->integer p)
   (void*->address (pointer-ptr p)))
-  
+
 )

--- a/src/pffi/compat.mosh.sls
+++ b/src/pffi/compat.mosh.sls
@@ -1,20 +1,20 @@
 ;;; -*- mode:scheme; coding: utf-8; -*-
 ;;;
 ;;; src/pffi/compat.mosh.sls - Compatible layer for Mosh
-;;;  
+;;;
 ;;;   Copyright (c) 2015  Takashi Kato  <ktakashi@ymail.com>
-;;;   
+;;;
 ;;;   Redistribution and use in source and binary forms, with or without
 ;;;   modification, are permitted provided that the following conditions
 ;;;   are met:
-;;;   
+;;;
 ;;;   1. Redistributions of source code must retain the above copyright
 ;;;      notice, this list of conditions and the following disclaimer.
-;;;  
+;;;
 ;;;   2. Redistributions in binary form must reproduce the above copyright
 ;;;      notice, this list of conditions and the following disclaimer in the
 ;;;      documentation and/or other materials provided with the distribution.
-;;;  
+;;;
 ;;;   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
 ;;;   "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
 ;;;   LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
@@ -26,7 +26,7 @@
 ;;;   LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
 ;;;   NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 ;;;   SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-;;;  
+;;;
 
 ;; this file provides compatible layer for (pffi procedure)
 ;; if implementations can't make this layer, then make
@@ -36,119 +36,119 @@
 #!r6rs
 (library (pffi compat)
     (export (rename (open-shared-library open-shared-object))
-	    (rename (lookup-shared-library lookup-shared-object))
-	    make-c-function
-	    make-c-callback
-	    free-c-callback
+            (rename (lookup-shared-library lookup-shared-object))
+            make-c-function
+            make-c-callback
+            free-c-callback
 
-	    ;; primitive types
-	    char  unsigned-char
-	    short unsigned-short
-	    int   unsigned-int
-	    long  unsigned-long
-	    float double
-	    int8_t  uint8_t
-	    int16_t uint16_t
-	    int32_t uint32_t
-	    int64_t uint64_t
-	    pointer callback
-	    void
+            ;; primitive types
+            char  unsigned-char
+            short unsigned-short
+            int   unsigned-int
+            long  unsigned-long
+            float double
+            int8_t  uint8_t
+            int16_t uint16_t
+            int32_t uint32_t
+            int64_t uint64_t
+            pointer callback
+            void
 
-	    ;; pointer ref
-	    pointer-ref-c-uint8
-	    pointer-ref-c-int8
-	    pointer-ref-c-uint16
-	    pointer-ref-c-int16
-	    pointer-ref-c-uint32
-	    pointer-ref-c-int32
-	    pointer-ref-c-uint64
-	    pointer-ref-c-int64
-	    pointer-ref-c-unsigned-char
-	    (rename (pointer-ref-c-signed-char pointer-ref-c-char))
-	    pointer-ref-c-unsigned-short
-	    pointer-ref-c-short
-	    pointer-ref-c-unsigned-int
-	    pointer-ref-c-int
-	    pointer-ref-c-unsigned-long
-	    pointer-ref-c-long
-	    pointer-ref-c-float
-	    pointer-ref-c-double
-	    pointer-ref-c-pointer
+            ;; pointer ref
+            pointer-ref-c-uint8
+            pointer-ref-c-int8
+            pointer-ref-c-uint16
+            pointer-ref-c-int16
+            pointer-ref-c-uint32
+            pointer-ref-c-int32
+            pointer-ref-c-uint64
+            pointer-ref-c-int64
+            pointer-ref-c-unsigned-char
+            (rename (pointer-ref-c-signed-char pointer-ref-c-char))
+            pointer-ref-c-unsigned-short
+            pointer-ref-c-short
+            pointer-ref-c-unsigned-int
+            pointer-ref-c-int
+            pointer-ref-c-unsigned-long
+            pointer-ref-c-long
+            pointer-ref-c-float
+            pointer-ref-c-double
+            pointer-ref-c-pointer
 
-	    ;; pointer set
-	    pointer-set-c-uint8!
-	    pointer-set-c-int8!
-	    pointer-set-c-uint16!
-	    pointer-set-c-int16!
-	    pointer-set-c-uint32!
-	    pointer-set-c-int32!
-	    pointer-set-c-uint64!
-	    pointer-set-c-int64!
-	    ;; Mosh doesn't have pointer-set for unsigned types
-	    ;; well we don't make effort
-	    (rename (pointer-set-c-char! pointer-set-c-unsigned-char!))
-	    pointer-set-c-char!
-	    pointer-set-c-unsigned-short!
-	    pointer-set-c-short!
-	    pointer-set-c-unsigned-int!
-	    pointer-set-c-int!
-	    pointer-set-c-unsigned-long!
-	    pointer-set-c-long!
-	    pointer-set-c-float!
-	    pointer-set-c-double!
-	    pointer-set-c-pointer!
+            ;; pointer set
+            pointer-set-c-uint8!
+            pointer-set-c-int8!
+            pointer-set-c-uint16!
+            pointer-set-c-int16!
+            pointer-set-c-uint32!
+            pointer-set-c-int32!
+            pointer-set-c-uint64!
+            pointer-set-c-int64!
+            ;; Mosh doesn't have pointer-set for unsigned types
+            ;; well we don't make effort
+            (rename (pointer-set-c-char! pointer-set-c-unsigned-char!))
+            pointer-set-c-char!
+            pointer-set-c-unsigned-short!
+            pointer-set-c-short!
+            pointer-set-c-unsigned-int!
+            pointer-set-c-int!
+            pointer-set-c-unsigned-long!
+            pointer-set-c-long!
+            pointer-set-c-float!
+            pointer-set-c-double!
+            pointer-set-c-pointer!
 
-	    size-of-char
-	    size-of-short
-	    size-of-int
-	    size-of-long
-	    size-of-float
-	    size-of-double
-	    size-of-pointer
-	    size-of-int8_t
-	    size-of-int16_t
-	    size-of-int32_t
-	    size-of-int64_t
+            size-of-char
+            size-of-short
+            size-of-int
+            size-of-long
+            size-of-float
+            size-of-double
+            size-of-pointer
+            size-of-int8_t
+            size-of-int16_t
+            size-of-int32_t
+            size-of-int64_t
 
-	    pointer?
-	    bytevector->pointer
-	    pointer->bytevector
-	    pointer->integer
-	    integer->pointer
-	    )
+            pointer?
+            bytevector->pointer
+            pointer->bytevector
+            pointer->integer
+            integer->pointer
+            )
     (import (rnrs)
-	    (rename (except (mosh ffi) 
-			    ;; Seems mosh computes offset as multiple of
-			    ;; sizeof(type). this I think inconvenient.
-			    pointer-ref-c-uint16
-			    pointer-ref-c-int16
-			    pointer-ref-c-uint32
-			    pointer-ref-c-int32
-			    pointer-ref-c-uint64
-			    pointer-ref-c-int64
-			    pointer-ref-c-unsigned-short
-			    pointer-ref-c-unsigned-int
-			    pointer-ref-c-unsigned-long
-			    pointer-ref-c-float
-			    pointer-ref-c-double
-			    pointer-ref-c-pointer
-			    pointer-set-c-uint16!
-			    pointer-set-c-int16!
-			    pointer-set-c-uint32!
-			    pointer-set-c-int32!
-			    pointer-set-c-uint64!
-			    pointer-set-c-int64!
-			    pointer-set-c-short!
-			    pointer-set-c-int!
-			    pointer-set-c-long!
-			    ;;pointer-set-c-unsigned-int!
-			    ;;pointer-set-c-unsigned-long!
-			    pointer-set-c-float!
-			    pointer-set-c-double!
-			    pointer-set-c-pointer!)
-		    (lookup-shared-library %lookup-shared-library))
-	    (rename (pffi bv-pointer) 
-		    (bytevector->pointer %bytevector->pointer)))
+            (rename (except (mosh ffi)
+                            ;; Seems mosh computes offset as multiple of
+                            ;; sizeof(type). this I think inconvenient.
+                            pointer-ref-c-uint16
+                            pointer-ref-c-int16
+                            pointer-ref-c-uint32
+                            pointer-ref-c-int32
+                            pointer-ref-c-uint64
+                            pointer-ref-c-int64
+                            pointer-ref-c-unsigned-short
+                            pointer-ref-c-unsigned-int
+                            pointer-ref-c-unsigned-long
+                            pointer-ref-c-float
+                            pointer-ref-c-double
+                            pointer-ref-c-pointer
+                            pointer-set-c-uint16!
+                            pointer-set-c-int16!
+                            pointer-set-c-uint32!
+                            pointer-set-c-int32!
+                            pointer-set-c-uint64!
+                            pointer-set-c-int64!
+                            pointer-set-c-short!
+                            pointer-set-c-int!
+                            pointer-set-c-long!
+                            ;;pointer-set-c-unsigned-int!
+                            ;;pointer-set-c-unsigned-long!
+                            pointer-set-c-float!
+                            pointer-set-c-double!
+                            pointer-set-c-pointer!)
+                    (lookup-shared-library %lookup-shared-library))
+            (rename (pffi bv-pointer)
+                    (bytevector->pointer %bytevector->pointer)))
 
 (define char           'char)
 (define unsigned-char  'unsigned-char)
@@ -199,33 +199,33 @@
   ;; we want shared bytevector
   (let ((offset (if (null? maybe-offset) 0 (car maybe-offset))))
     (do ((bv (make-bytevector len)) (i 0 (+ i 1)))
-	((= i len) bv)
+        ((= i len) bv)
       (bytevector-u8-set! bv i (pointer-ref-c-uint8 p (+ i offset))))))
 
 (define-syntax define-deref
   (lambda (x)
     (define (gen-name t)
       (let ((s (symbol->string (syntax->datum t))))
-	(list (string->symbol (string-append "size-of-" s))
-	      (string->symbol (string-append "pointer-ref-c-" s))
-	      (string->symbol (string-append "pointer-set-c-" s "!")))))
+        (list (string->symbol (string-append "size-of-" s))
+              (string->symbol (string-append "pointer-ref-c-" s))
+              (string->symbol (string-append "pointer-set-c-" s "!")))))
     (syntax-case x ()
       ((k type bv-ref ->bv)
        (with-syntax (((size ref set!) (datum->syntax #'k (gen-name #'type))))
-	 #'(begin
-	     (define (ref ptr offset)
-	       (let ((bv (make-bytevector size)))
-		 (do ((i 0 (+ i 1))) 
-		     ((= i size) (bv-ref bv 0 (native-endianness)))
-		   (bytevector-u8-set! bv i 
-		       (pointer-ref-c-uint8 ptr (+ i offset))))))
-	     (define (set! ptr offset value)
-	       (let ((bv (->bv value)))
-		 (do ((len (bytevector-length bv))
-		      (i 0 (+ i 1)))
-		     ((= i len))
-		   (pointer-set-c-uint8! ptr (+ i offset)
-					 (bytevector-u8-ref bv i)))))))))))
+         #'(begin
+             (define (ref ptr offset)
+               (let ((bv (make-bytevector size)))
+                 (do ((i 0 (+ i 1)))
+                     ((= i size) (bv-ref bv 0 (native-endianness)))
+                   (bytevector-u8-set! bv i
+                       (pointer-ref-c-uint8 ptr (+ i offset))))))
+             (define (set! ptr offset value)
+               (let ((bv (->bv value)))
+                 (do ((len (bytevector-length bv))
+                      (i 0 (+ i 1)))
+                     ((= i len))
+                   (pointer-set-c-uint8! ptr (+ i offset)
+                                         (bytevector-u8-ref bv i)))))))))))
 
 ;; kinda tricky
 (define (bytevector-long-ref bv index endian)
@@ -285,9 +285,9 @@
 (define-deref int64 bytevector-s64-ref s64->bv)
 (define-deref uint64 bytevector-u64-ref u64->bv)
 
-(define (pointer->bv p) 
+(define (pointer->bv p)
   (uint-list->bytevector (list (pointer->integer p))
-			 (native-endianness) size-of-pointer))
+                         (native-endianness) size-of-pointer))
 (define-deref pointer bytevector-pointer-ref pointer->bv)
 
 

--- a/src/pffi/compat.mzscheme.sls
+++ b/src/pffi/compat.mzscheme.sls
@@ -1,20 +1,20 @@
 ;;; -*- mode:scheme; coding: utf-8; -*-
 ;;;
 ;;; src/pffi/compat.mzscheme.sls - Compatible layer for Racket
-;;;  
+;;;
 ;;;   Copyright (c) 2015  Takashi Kato  <ktakashi@ymail.com>
-;;;   
+;;;
 ;;;   Redistribution and use in source and binary forms, with or without
 ;;;   modification, are permitted provided that the following conditions
 ;;;   are met:
-;;;   
+;;;
 ;;;   1. Redistributions of source code must retain the above copyright
 ;;;      notice, this list of conditions and the following disclaimer.
-;;;  
+;;;
 ;;;   2. Redistributions in binary form must reproduce the above copyright
 ;;;      notice, this list of conditions and the following disclaimer in the
 ;;;      documentation and/or other materials provided with the distribution.
-;;;  
+;;;
 ;;;   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
 ;;;   "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
 ;;;   LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
@@ -26,7 +26,7 @@
 ;;;   LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
 ;;;   NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 ;;;   SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-;;;  
+;;;
 
 ;; this file provides compatible layer for (pffi procedure)
 ;; if implementations can't make this layer, then make
@@ -36,91 +36,91 @@
 #!r6rs
 (library (pffi compat)
     (export open-shared-object
-	    lookup-shared-object
+            lookup-shared-object
 
-	    make-c-function
-	    make-c-callback
-	    free-c-callback
+            make-c-function
+            make-c-callback
+            free-c-callback
 
-	    ;; primitive types
-	    char  unsigned-char
-	    short unsigned-short
-	    int   unsigned-int
-	    long  unsigned-long
-	    float double
-	    int8_t  uint8_t
-	    int16_t uint16_t
-	    int32_t uint32_t
-	    int64_t uint64_t
-	    pointer callback
-	    void
-	    
-	    ;; pointer ref
-	    pointer-ref-c-uint8
-	    pointer-ref-c-int8
-	    pointer-ref-c-uint16
-	    pointer-ref-c-int16
-	    pointer-ref-c-uint32
-	    pointer-ref-c-int32
-	    pointer-ref-c-uint64
-	    pointer-ref-c-int64
-	    pointer-ref-c-unsigned-char
-	    pointer-ref-c-char
-	    pointer-ref-c-unsigned-short
-	    pointer-ref-c-short
-	    pointer-ref-c-unsigned-int
-	    pointer-ref-c-int
-	    pointer-ref-c-unsigned-long
-	    pointer-ref-c-long
-	    pointer-ref-c-float
-	    pointer-ref-c-double
-	    pointer-ref-c-pointer
+            ;; primitive types
+            char  unsigned-char
+            short unsigned-short
+            int   unsigned-int
+            long  unsigned-long
+            float double
+            int8_t  uint8_t
+            int16_t uint16_t
+            int32_t uint32_t
+            int64_t uint64_t
+            pointer callback
+            void
 
-	    ;; pointer set
-	    pointer-set-c-uint8!
-	    pointer-set-c-int8!
-	    pointer-set-c-uint16!
-	    pointer-set-c-int16!
-	    pointer-set-c-uint32!
-	    pointer-set-c-int32!
-	    pointer-set-c-uint64!
-	    pointer-set-c-int64!
-	    pointer-set-c-unsigned-char!
-	    pointer-set-c-char!
-	    pointer-set-c-unsigned-short!
-	    pointer-set-c-short!
-	    pointer-set-c-unsigned-int!
-	    pointer-set-c-int!
-	    pointer-set-c-unsigned-long!
-	    pointer-set-c-long!
-	    pointer-set-c-float!
-	    pointer-set-c-double!
-	    pointer-set-c-pointer!
+            ;; pointer ref
+            pointer-ref-c-uint8
+            pointer-ref-c-int8
+            pointer-ref-c-uint16
+            pointer-ref-c-int16
+            pointer-ref-c-uint32
+            pointer-ref-c-int32
+            pointer-ref-c-uint64
+            pointer-ref-c-int64
+            pointer-ref-c-unsigned-char
+            pointer-ref-c-char
+            pointer-ref-c-unsigned-short
+            pointer-ref-c-short
+            pointer-ref-c-unsigned-int
+            pointer-ref-c-int
+            pointer-ref-c-unsigned-long
+            pointer-ref-c-long
+            pointer-ref-c-float
+            pointer-ref-c-double
+            pointer-ref-c-pointer
 
-	    size-of-char
-	    size-of-short
-	    size-of-int
-	    size-of-long
-	    size-of-float
-	    size-of-double
-	    size-of-pointer
-	    size-of-int8_t
-	    size-of-int16_t
-	    size-of-int32_t
-	    size-of-int64_t
+            ;; pointer set
+            pointer-set-c-uint8!
+            pointer-set-c-int8!
+            pointer-set-c-uint16!
+            pointer-set-c-int16!
+            pointer-set-c-uint32!
+            pointer-set-c-int32!
+            pointer-set-c-uint64!
+            pointer-set-c-int64!
+            pointer-set-c-unsigned-char!
+            pointer-set-c-char!
+            pointer-set-c-unsigned-short!
+            pointer-set-c-short!
+            pointer-set-c-unsigned-int!
+            pointer-set-c-int!
+            pointer-set-c-unsigned-long!
+            pointer-set-c-long!
+            pointer-set-c-float!
+            pointer-set-c-double!
+            pointer-set-c-pointer!
 
-	    (rename (cpointer? pointer?))
-	    bytevector->pointer
-	    pointer->bytevector
-	    pointer->integer
-	    integer->pointer
-	    )
+            size-of-char
+            size-of-short
+            size-of-int
+            size-of-long
+            size-of-float
+            size-of-double
+            size-of-pointer
+            size-of-int8_t
+            size-of-int16_t
+            size-of-int32_t
+            size-of-int64_t
+
+            (rename (cpointer? pointer?))
+            bytevector->pointer
+            pointer->bytevector
+            pointer->integer
+            integer->pointer
+            )
     (import (rnrs)
-	    (ffi unsafe)
-	    (ffi vector)
-	    (rename (only (racket base) cons) (cons icons))
-	    (only (srfi :13) string-index-right))
- 
+            (ffi unsafe)
+            (ffi vector)
+            (rename (only (racket base) cons) (cons icons))
+            (only (srfi :13) string-index-right))
+
 (define char           _sint8)
 (define unsigned-char  _uint8)
 (define short          _sshort)
@@ -159,9 +159,9 @@
 
 (define (open-shared-object path)
   (let* ((index (string-index-right path #\.))
-	 (file (if index
-		   (substring path 0 index)
-		   path)))
+         (file (if index
+                   (substring path 0 index)
+                   path)))
     (ffi-lib file)))
 
 (define (lookup-shared-object lib name)
@@ -173,18 +173,18 @@
 (define (->immutable-list p)
   (let loop ((p p))
     (cond ((null? p) p)
-	  ((pair? p) (icons (car p) (loop (cdr p))))
-	  (else p))))
-	
+          ((pair? p) (icons (car p) (loop (cdr p))))
+          (else p))))
+
 
 (define (make-c-function lib ret name arg-type)
   ;; TODO failure thunk, what should we do when it couldn't be found
-  (get-ffi-obj (symbol->string name) lib 
-	       ;; DAMN YOU MORON!!!
-	       ;; seems this doesn't accept mutable pairs
-	       ;; so convert it.
-	       (_cprocedure (->immutable-list arg-type) ret)
-	       (lambda () (error 'make-c-function "not found" name))))
+  (get-ffi-obj (symbol->string name) lib
+               ;; DAMN YOU MORON!!!
+               ;; seems this doesn't accept mutable pairs
+               ;; so convert it.
+               (_cprocedure (->immutable-list arg-type) ret)
+               (lambda () (error 'make-c-function "not found" name))))
 
 (define (make-c-callback ret args proc) proc)
 
@@ -196,29 +196,29 @@
   (lambda (x)
     (define (gen-name t)
       (let ((s (symbol->string (syntax->datum t))))
-	(list (string->symbol (string-append "size-of-" s))
-	      (string->symbol (string-append "pointer-ref-c-" s))
-	      (string->symbol (string-append "pointer-set-c-" s "!")))))
+        (list (string->symbol (string-append "size-of-" s))
+              (string->symbol (string-append "pointer-ref-c-" s))
+              (string->symbol (string-append "pointer-set-c-" s "!")))))
     (syntax-case x ()
       ((k type ->bv)
        (with-syntax (((size ref set!) (datum->syntax #'k (gen-name #'type))))
-	 #'(begin
-	     ;; ref/set as a byte so that we can specify detailed offset
-	     ;; e.g. 
-	     ;;  (pointer-ref-c-uint64 p 1)
-	     ;;  will refer a value from one byte offset
-	     (define (ref ptr offset)
-	       (let ((bv (make-bytevector size)))
-		 (do ((i 0 (+ i 1)))
-		     ((= i size) (ptr-ref bv type 0))
-		   (bytevector-u8-set! bv i
-		       (ptr-ref ptr unsigned-char (+ i offset))))))
-	     (define (set! ptr offset value)
-	       (let ((bv (->bv value)))
-		 (do ((len (bytevector-length bv)) (i 0 (+ i 1)))
-		     ((= i len))
-		   (ptr-set! ptr unsigned-char (+ offset i)
-			     (bytevector-u8-ref bv i)))))))))))
+         #'(begin
+             ;; ref/set as a byte so that we can specify detailed offset
+             ;; e.g.
+             ;;  (pointer-ref-c-uint64 p 1)
+             ;;  will refer a value from one byte offset
+             (define (ref ptr offset)
+               (let ((bv (make-bytevector size)))
+                 (do ((i 0 (+ i 1)))
+                     ((= i size) (ptr-ref bv type 0))
+                   (bytevector-u8-set! bv i
+                       (ptr-ref ptr unsigned-char (+ i offset))))))
+             (define (set! ptr offset value)
+               (let ((bv (->bv value)))
+                 (do ((len (bytevector-length bv)) (i 0 (+ i 1)))
+                     ((= i len))
+                   (ptr-set! ptr unsigned-char (+ offset i)
+                             (bytevector-u8-ref bv i)))))))))))
 
 (define-syntax define-uint->bv
   (syntax-rules ()
@@ -269,29 +269,29 @@
 (define-deref int64 s64->bv)
 (define-deref uint64 u64->bv)
 
-(define (pointer-ref-c-pointer p offset) 
+(define (pointer-ref-c-pointer p offset)
   (let ((bv (make-bytevector size-of-pointer)))
     (do ((i 0 (+ i 1)))
-	((= i size-of-pointer) (ptr-ref bv pointer 0))
+        ((= i size-of-pointer) (ptr-ref bv pointer 0))
       (bytevector-u8-set! bv i (pointer-ref-c-uint8 p (+ i offset))))))
-(define (pointer-set-c-pointer! p offset v) 
+(define (pointer-set-c-pointer! p offset v)
   (let* ((pv (pointer->integer v))
-	 (bv (uint-list->bytevector (list pv) 
-				    (native-endianness) size-of-pointer)))
+         (bv (uint-list->bytevector (list pv)
+                                    (native-endianness) size-of-pointer)))
     (do ((i 0 (+ i 1)))
-	((= i size-of-pointer))
+        ((= i size-of-pointer))
       (pointer-set-c-uint8! p (+ i offset) (bytevector-u8-ref bv i)))))
 
 (define-syntax define-sizeof
   (lambda (x)
     (define (gen-name t)
       (let ((s (symbol->string (syntax->datum t))))
-	(string->symbol (string-append "size-of-" s))))
+        (string->symbol (string-append "size-of-" s))))
     (syntax-case x ()
       ((k type)
        (with-syntax ((name (datum->syntax #'k (gen-name #'type))))
-	 #'(define name
-	     (ctype-sizeof type)))))))
+         #'(define name
+             (ctype-sizeof type)))))))
 (define-sizeof char)
 (define-sizeof short)
 (define-sizeof int)

--- a/src/pffi/compat.sagittarius.sls
+++ b/src/pffi/compat.sagittarius.sls
@@ -1,20 +1,20 @@
 ;;; -*- mode:scheme; coding: utf-8; -*-
 ;;;
 ;;; src/pffi/compat.sagittarius.sls - Compatible layer for Sagittarius
-;;;  
+;;;
 ;;;   Copyright (c) 2015  Takashi Kato  <ktakashi@ymail.com>
-;;;   
+;;;
 ;;;   Redistribution and use in source and binary forms, with or without
 ;;;   modification, are permitted provided that the following conditions
 ;;;   are met:
-;;;   
+;;;
 ;;;   1. Redistributions of source code must retain the above copyright
 ;;;      notice, this list of conditions and the following disclaimer.
-;;;  
+;;;
 ;;;   2. Redistributions in binary form must reproduce the above copyright
 ;;;      notice, this list of conditions and the following disclaimer in the
 ;;;      documentation and/or other materials provided with the distribution.
-;;;  
+;;;
 ;;;   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
 ;;;   "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
 ;;;   LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
@@ -26,7 +26,7 @@
 ;;;   LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
 ;;;   NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 ;;;   SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-;;;  
+;;;
 
 ;; this file provides compatible layer for (pffi procedure)
 ;; if implementations can't make this layer, then make
@@ -36,103 +36,103 @@
 #!r6rs
 (library (pffi compat)
     (export (rename (open-shared-library open-shared-object))
-	    (rename (lookup-shared-library lookup-shared-object))
-	    make-c-function
-	    make-c-callback
-	    free-c-callback
+            (rename (lookup-shared-library lookup-shared-object))
+            make-c-function
+            make-c-callback
+            free-c-callback
 
-	    ;; primitive types
-	    char  unsigned-char
-	    short unsigned-short
-	    int   unsigned-int
-	    long  unsigned-long
-	    float double
-	    int8_t  uint8_t
-	    int16_t uint16_t
-	    int32_t uint32_t
-	    int64_t uint64_t
-	    pointer callback
-	    void
+            ;; primitive types
+            char  unsigned-char
+            short unsigned-short
+            int   unsigned-int
+            long  unsigned-long
+            float double
+            int8_t  uint8_t
+            int16_t uint16_t
+            int32_t uint32_t
+            int64_t uint64_t
+            pointer callback
+            void
 
-	    ;; pointer ref
-	    pointer-ref-c-uint8
-	    pointer-ref-c-int8
-	    pointer-ref-c-uint16
-	    pointer-ref-c-int16
-	    pointer-ref-c-uint32
-	    pointer-ref-c-int32
-	    pointer-ref-c-uint64
-	    pointer-ref-c-int64
-	    ;; should we define them?
-	    ;; pointer-ref-c-uint8_t
-	    ;; pointer-ref-c-int8_t	 
-	    ;; pointer-ref-c-uint16_t
-	    ;; pointer-ref-c-int16_t
-	    ;; pointer-ref-c-uint32_t
-	    ;; pointer-ref-c-int32_t
-	    ;; pointer-ref-c-uint64_t
-	    ;; pointer-ref-c-int64_t
-	    pointer-ref-c-unsigned-char
-	    pointer-ref-c-char
-	    pointer-ref-c-unsigned-short
-	    pointer-ref-c-short
-	    pointer-ref-c-unsigned-int
-	    pointer-ref-c-int
-	    pointer-ref-c-unsigned-long
-	    pointer-ref-c-long
-	    pointer-ref-c-float
-	    pointer-ref-c-double
-	    pointer-ref-c-pointer
+            ;; pointer ref
+            pointer-ref-c-uint8
+            pointer-ref-c-int8
+            pointer-ref-c-uint16
+            pointer-ref-c-int16
+            pointer-ref-c-uint32
+            pointer-ref-c-int32
+            pointer-ref-c-uint64
+            pointer-ref-c-int64
+            ;; should we define them?
+            ;; pointer-ref-c-uint8_t
+            ;; pointer-ref-c-int8_t
+            ;; pointer-ref-c-uint16_t
+            ;; pointer-ref-c-int16_t
+            ;; pointer-ref-c-uint32_t
+            ;; pointer-ref-c-int32_t
+            ;; pointer-ref-c-uint64_t
+            ;; pointer-ref-c-int64_t
+            pointer-ref-c-unsigned-char
+            pointer-ref-c-char
+            pointer-ref-c-unsigned-short
+            pointer-ref-c-short
+            pointer-ref-c-unsigned-int
+            pointer-ref-c-int
+            pointer-ref-c-unsigned-long
+            pointer-ref-c-long
+            pointer-ref-c-float
+            pointer-ref-c-double
+            pointer-ref-c-pointer
 
-	    ;; pointer set
-	    pointer-set-c-uint8!
-	    pointer-set-c-int8!
-	    pointer-set-c-uint16!
-	    pointer-set-c-int16!
-	    pointer-set-c-uint32!
-	    pointer-set-c-int32!
-	    pointer-set-c-uint64!
-	    pointer-set-c-int64!
-	    pointer-set-c-unsigned-char!
-	    pointer-set-c-char!
-	    pointer-set-c-unsigned-short!
-	    pointer-set-c-short!
-	    pointer-set-c-unsigned-int!
-	    pointer-set-c-int!
-	    pointer-set-c-unsigned-long!
-	    pointer-set-c-long!
-	    pointer-set-c-float!
-	    pointer-set-c-double!
-	    pointer-set-c-pointer!
-	    
-	    ;; sizeof
-	    size-of-char
-	    size-of-short
-	    size-of-int
-	    size-of-long
-	    size-of-float
-	    size-of-double
-	    (rename (size-of-void* size-of-pointer))
-	    size-of-int8_t
-	    size-of-int16_t
-	    size-of-int32_t
-	    size-of-int64_t
+            ;; pointer set
+            pointer-set-c-uint8!
+            pointer-set-c-int8!
+            pointer-set-c-uint16!
+            pointer-set-c-int16!
+            pointer-set-c-uint32!
+            pointer-set-c-int32!
+            pointer-set-c-uint64!
+            pointer-set-c-int64!
+            pointer-set-c-unsigned-char!
+            pointer-set-c-char!
+            pointer-set-c-unsigned-short!
+            pointer-set-c-short!
+            pointer-set-c-unsigned-int!
+            pointer-set-c-int!
+            pointer-set-c-unsigned-long!
+            pointer-set-c-long!
+            pointer-set-c-float!
+            pointer-set-c-double!
+            pointer-set-c-pointer!
 
-	    pointer?
-	    bytevector->pointer
-	    pointer->bytevector
-	    pointer->integer
-	    (rename (uinteger->pointer integer->pointer))
-	    )
+            ;; sizeof
+            size-of-char
+            size-of-short
+            size-of-int
+            size-of-long
+            size-of-float
+            size-of-double
+            (rename (size-of-void* size-of-pointer))
+            size-of-int8_t
+            size-of-int16_t
+            size-of-int32_t
+            size-of-int64_t
+
+            pointer?
+            bytevector->pointer
+            pointer->bytevector
+            pointer->integer
+            (rename (uinteger->pointer integer->pointer))
+            )
     (import (rnrs)
-	    (rename (sagittarius ffi) (callback %callback))
-	    (sagittarius control))
+            (rename (sagittarius ffi) (callback %callback))
+            (sagittarius control))
 
 (define-syntax callback
   (syntax-rules ()
     ((_ ignore ...) %callback)))
 (define pointer void*)
 
-;; Since 0.6.4, this is available 
+;; Since 0.6.4, this is available
 ;; (define make-c-callback (with-library (sagittarius ffi) make-c-callback))
 )

--- a/src/pffi/compat.vicare.sls
+++ b/src/pffi/compat.vicare.sls
@@ -1,20 +1,20 @@
 ;;; -*- mode:scheme; coding: utf-8; -*-
 ;;;
 ;;; src/pffi/compat.vicare.sls - Compatible layer for Vicare
-;;;  
+;;;
 ;;;   Copyright (c) 2015  Takashi Kato  <ktakashi@ymail.com>
-;;;   
+;;;
 ;;;   Redistribution and use in source and binary forms, with or without
 ;;;   modification, are permitted provided that the following conditions
 ;;;   are met:
-;;;   
+;;;
 ;;;   1. Redistributions of source code must retain the above copyright
 ;;;      notice, this list of conditions and the following disclaimer.
-;;;  
+;;;
 ;;;   2. Redistributions in binary form must reproduce the above copyright
 ;;;      notice, this list of conditions and the following disclaimer in the
 ;;;      documentation and/or other materials provided with the distribution.
-;;;  
+;;;
 ;;;   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
 ;;;   "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
 ;;;   LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
@@ -26,7 +26,7 @@
 ;;;   LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
 ;;;   NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 ;;;   SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-;;;  
+;;;
 
 ;; this file provides compatible layer for (pffi procedure)
 ;; if implementations can't make this layer, then make
@@ -35,127 +35,127 @@
 
 #!r6rs
 (library (pffi compat)
-    (export open-shared-object	 ;; form (vicare ffi)
-	    (rename (%lookup-shared-object lookup-shared-object))
-	    make-c-function
-	    make-c-callback
-	    free-c-callback
+    (export open-shared-object   ;; form (vicare ffi)
+            (rename (%lookup-shared-object lookup-shared-object))
+            make-c-function
+            make-c-callback
+            free-c-callback
 
-	    ;; primitive types
-	    char  unsigned-char
-	    short unsigned-short
-	    int   unsigned-int
-	    long  unsigned-long
-	    float double
-	    int8_t  uint8_t
-	    int16_t uint16_t
-	    int32_t uint32_t
-	    int64_t uint64_t
-	    pointer callback
-	    void
+            ;; primitive types
+            char  unsigned-char
+            short unsigned-short
+            int   unsigned-int
+            long  unsigned-long
+            float double
+            int8_t  uint8_t
+            int16_t uint16_t
+            int32_t uint32_t
+            int64_t uint64_t
+            pointer callback
+            void
 
-	    pointer-ref-c-uint8
-	    pointer-ref-c-int8
-	    pointer-ref-c-uint16
-	    pointer-ref-c-int16
-	    pointer-ref-c-uint32
-	    pointer-ref-c-int32
-	    pointer-ref-c-uint64
-	    pointer-ref-c-int64
-	    pointer-ref-c-unsigned-char
-	    pointer-ref-c-char
-	    pointer-ref-c-unsigned-short
-	    pointer-ref-c-short
-	    pointer-ref-c-unsigned-int
-	    pointer-ref-c-int
-	    pointer-ref-c-unsigned-long
-	    pointer-ref-c-long
-	    pointer-ref-c-float
-	    pointer-ref-c-double
-	    pointer-ref-c-pointer
+            pointer-ref-c-uint8
+            pointer-ref-c-int8
+            pointer-ref-c-uint16
+            pointer-ref-c-int16
+            pointer-ref-c-uint32
+            pointer-ref-c-int32
+            pointer-ref-c-uint64
+            pointer-ref-c-int64
+            pointer-ref-c-unsigned-char
+            pointer-ref-c-char
+            pointer-ref-c-unsigned-short
+            pointer-ref-c-short
+            pointer-ref-c-unsigned-int
+            pointer-ref-c-int
+            pointer-ref-c-unsigned-long
+            pointer-ref-c-long
+            pointer-ref-c-float
+            pointer-ref-c-double
+            pointer-ref-c-pointer
 
-	    ;; pointer set
-	    pointer-set-c-uint8!
-	    pointer-set-c-int8!
-	    pointer-set-c-uint16!
-	    pointer-set-c-int16!
-	    pointer-set-c-uint32!
-	    pointer-set-c-int32!
-	    pointer-set-c-uint64!
-	    pointer-set-c-int64!
-	    pointer-set-c-unsigned-char!
-	    pointer-set-c-char!
-	    pointer-set-c-unsigned-short!
-	    pointer-set-c-short!
-	    pointer-set-c-unsigned-int!
-	    pointer-set-c-int!
-	    pointer-set-c-unsigned-long!
-	    pointer-set-c-long!
-	    pointer-set-c-float!
-	    pointer-set-c-double!
-	    pointer-set-c-pointer!
-	    
-	    ;; sizeof
-	    size-of-char
-	    size-of-short
-	    size-of-int
-	    size-of-long
-	    size-of-float
-	    size-of-double
-	    size-of-pointer
-	    size-of-int8_t
-	    size-of-int16_t
-	    size-of-int32_t
-	    size-of-int64_t
+            ;; pointer set
+            pointer-set-c-uint8!
+            pointer-set-c-int8!
+            pointer-set-c-uint16!
+            pointer-set-c-int16!
+            pointer-set-c-uint32!
+            pointer-set-c-int32!
+            pointer-set-c-uint64!
+            pointer-set-c-int64!
+            pointer-set-c-unsigned-char!
+            pointer-set-c-char!
+            pointer-set-c-unsigned-short!
+            pointer-set-c-short!
+            pointer-set-c-unsigned-int!
+            pointer-set-c-int!
+            pointer-set-c-unsigned-long!
+            pointer-set-c-long!
+            pointer-set-c-float!
+            pointer-set-c-double!
+            pointer-set-c-pointer!
 
-	    (rename (pointer-wrapper? pointer?))
-	    bytevector->pointer
-	    pointer->bytevector
-	    (rename (%pointer->integer pointer->integer)
-		    (%integer->pointer integer->pointer))
-	    )
+            ;; sizeof
+            size-of-char
+            size-of-short
+            size-of-int
+            size-of-long
+            size-of-float
+            size-of-double
+            size-of-pointer
+            size-of-int8_t
+            size-of-int16_t
+            size-of-int32_t
+            size-of-int64_t
+
+            (rename (pointer-wrapper? pointer?))
+            bytevector->pointer
+            pointer->bytevector
+            (rename (%pointer->integer pointer->integer)
+                    (%integer->pointer integer->pointer))
+            )
     (import (rnrs)
-	    (rename (except (vicare ffi)
-			    pointer-ref-c-sint8
-			    pointer-ref-c-uint16
-			    pointer-ref-c-sint16
-			    pointer-ref-c-uint32
-			    pointer-ref-c-sint32
-			    pointer-ref-c-uint64
-			    pointer-ref-c-sint64
-			    pointer-ref-c-unsigned-char
-			    pointer-ref-c-unsigned-short
-			    pointer-ref-c-unsigned-int
-			    pointer-ref-c-unsigned-long
-			    pointer-ref-c-float
-			    pointer-ref-c-double
-			    pointer-ref-c-pointer
-			    pointer-set-c-sint8!
-			    pointer-set-c-uint16!
-			    pointer-set-c-sint16!
-			    pointer-set-c-uint32!
-			    pointer-set-c-sint32!
-			    pointer-set-c-uint64!
-			    pointer-set-c-sint64!
-			    pointer-set-c-short!
-			    pointer-set-c-sint!
-			    pointer-set-c-unsigned-char!
-			    pointer-set-c-unsigned-short!
-			    pointer-set-c-unsigned-int!
-			    pointer-set-c-unsigned-long!
-			    pointer-set-c-float!
-			    pointer-set-c-double!
-			    pointer-set-c-pointer!)
-		    (pointer-ref-c-uint8 %pointer-ref-c-uint8)
-		    (pointer-set-c-uint8! %pointer-set-c-uint8!))
-	    (rename (vicare platform words)
-		    (SIZEOF_CHAR    size-of-char)
-		    (SIZEOF_SHORT   size-of-short)
-		    (SIZEOF_INT     size-of-int)	     
-		    (SIZEOF_LONG    size-of-long)
-		    (SIZEOF_FLOAT   size-of-float)
-		    (SIZEOF_DOUBLE  size-of-double)
-		    (SIZEOF_POINTER size-of-pointer)))
+            (rename (except (vicare ffi)
+                            pointer-ref-c-sint8
+                            pointer-ref-c-uint16
+                            pointer-ref-c-sint16
+                            pointer-ref-c-uint32
+                            pointer-ref-c-sint32
+                            pointer-ref-c-uint64
+                            pointer-ref-c-sint64
+                            pointer-ref-c-unsigned-char
+                            pointer-ref-c-unsigned-short
+                            pointer-ref-c-unsigned-int
+                            pointer-ref-c-unsigned-long
+                            pointer-ref-c-float
+                            pointer-ref-c-double
+                            pointer-ref-c-pointer
+                            pointer-set-c-sint8!
+                            pointer-set-c-uint16!
+                            pointer-set-c-sint16!
+                            pointer-set-c-uint32!
+                            pointer-set-c-sint32!
+                            pointer-set-c-uint64!
+                            pointer-set-c-sint64!
+                            pointer-set-c-short!
+                            pointer-set-c-sint!
+                            pointer-set-c-unsigned-char!
+                            pointer-set-c-unsigned-short!
+                            pointer-set-c-unsigned-int!
+                            pointer-set-c-unsigned-long!
+                            pointer-set-c-float!
+                            pointer-set-c-double!
+                            pointer-set-c-pointer!)
+                    (pointer-ref-c-uint8 %pointer-ref-c-uint8)
+                    (pointer-set-c-uint8! %pointer-set-c-uint8!))
+            (rename (vicare platform words)
+                    (SIZEOF_CHAR    size-of-char)
+                    (SIZEOF_SHORT   size-of-short)
+                    (SIZEOF_INT     size-of-int)
+                    (SIZEOF_LONG    size-of-long)
+                    (SIZEOF_FLOAT   size-of-float)
+                    (SIZEOF_DOUBLE  size-of-double)
+                    (SIZEOF_POINTER size-of-pointer)))
 
 
 (define char           'signed-char)
@@ -187,47 +187,47 @@
 (define (sync-pointer arg)
   (when (pointer-wrapper? arg)
     (let* ((dst (pointer-bytevector arg))
-	   (len (bytevector-length dst))
-	   (src (memory->bytevector (pointer-memory arg) len)))
+           (len (bytevector-length dst))
+           (src (memory->bytevector (pointer-memory arg) len)))
       (bytevector-copy! src 0 dst 0 len))))
 
 (define (make-c-function lib ret name arg-type)
   (define (pointer-handler f)
     (define (pointer/value arg)
       (if (pointer-wrapper? arg)
-	  (pointer-memory arg)
-	  arg))
+          (pointer-memory arg)
+          arg))
     (define (->pointer arg)
       (if (pointer? arg)
-	  (make-pointer-wrapper (memory->bytevector arg size-of-pointer) arg)
-	  arg))
+          (make-pointer-wrapper (memory->bytevector arg size-of-pointer) arg)
+          arg))
     (lambda args
       (let-values ((results (apply f (map pointer/value args))))
-	(for-each sync-pointer args)
-	;; do foreign-procedures return multiple values?
-	(apply values (map ->pointer results)))))
+        (for-each sync-pointer args)
+        ;; do foreign-procedures return multiple values?
+        (apply values (map ->pointer results)))))
   (let ((func (lookup-shared-object lib (symbol->string name)))
-	(m (make-c-callout-maker ret arg-type)))
+        (m (make-c-callout-maker ret arg-type)))
     (pointer-handler (m func))))
 
 (define (%lookup-shared-object lib name)
   (let ((raw-ptr (lookup-shared-object lib name)))
     (make-pointer-wrapper (memory->bytevector raw-ptr size-of-pointer)
-			  raw-ptr)))
+                          raw-ptr)))
 
 ;; FIXME, this probably doesn't work
 (define (make-c-callback ret args proc)
   (define (pointer-handler f)
     (define (pointer/value arg)
       (if (pointer? arg)
-	  ;; TODO is this true?
-	  (make-pointer-wrapper (memory->bytevector arg size-of-pointer) arg)
-	  arg))
+          ;; TODO is this true?
+          (make-pointer-wrapper (memory->bytevector arg size-of-pointer) arg)
+          arg))
     (lambda args
       (let-values ((results (apply f (map pointer/value args))))
-	;; (for-each sync-pointer results)
-	;; argument is passed from foreign world
-	(apply values results))))
+        ;; (for-each sync-pointer results)
+        ;; argument is passed from foreign world
+        (apply values results))))
   (let ((m (make-c-callback-maker ret args)))
     (m (pointer-handler proc))))
 
@@ -259,7 +259,7 @@
 
 (define-record-type pointer-wrapper
   (fields (immutable bytevector pointer-bytevector)
-	  (immutable memory pointer-memory)))
+          (immutable memory pointer-memory)))
 
 (define (bytevector->pointer bv . maybe-offset)
   ;; unfortunately, there is no procedure which can make a pointer
@@ -279,28 +279,28 @@
   (lambda (x)
     (define (gen-name t)
       (let ((s (symbol->string (syntax->datum t))))
-	(list (string->symbol (string-append "size-of-" s))
-	      (string->symbol (string-append "pointer-ref-c-" s))
-	      (string->symbol (string-append "pointer-set-c-" s "!")))))
+        (list (string->symbol (string-append "size-of-" s))
+              (string->symbol (string-append "pointer-ref-c-" s))
+              (string->symbol (string-append "pointer-set-c-" s "!")))))
     (syntax-case x ()
       ((k type bv-ref ->bv)
        (with-syntax (((size ref set!) (datum->syntax #'k (gen-name #'type))))
-	 #'(begin
-	     (define (ref ptr offset)
-	       (let ((bv (make-bytevector size))
-		     (p (pointer-memory ptr)))
-		 (do ((i 0 (+ i 1))) 
-		     ((= i size) (bv-ref bv 0 (native-endianness)))
-		   (bytevector-u8-set! bv i 
-		       (%pointer-ref-c-uint8 p (+ i offset))))))
-	     (define (set! ptr offset value)
-	       (let ((bv (->bv value))
-		     (p (pointer-memory ptr)))
-		 (do ((len (bytevector-length bv))
-		      (i 0 (+ i 1)))
-		     ((= i len) (sync-pointer ptr))
-		   (%pointer-set-c-uint8! p (+ i offset)
-					 (bytevector-u8-ref bv i)))))))))))
+         #'(begin
+             (define (ref ptr offset)
+               (let ((bv (make-bytevector size))
+                     (p (pointer-memory ptr)))
+                 (do ((i 0 (+ i 1)))
+                     ((= i size) (bv-ref bv 0 (native-endianness)))
+                   (bytevector-u8-set! bv i
+                       (%pointer-ref-c-uint8 p (+ i offset))))))
+             (define (set! ptr offset value)
+               (let ((bv (->bv value))
+                     (p (pointer-memory ptr)))
+                 (do ((len (bytevector-length bv))
+                      (i 0 (+ i 1)))
+                     ((= i len) (sync-pointer ptr))
+                   (%pointer-set-c-uint8! p (+ i offset)
+                                         (bytevector-u8-ref bv i)))))))))))
 
 ;; kinda tricky
 (define (bytevector-long-ref bv index endian)
@@ -367,23 +367,23 @@
 
 (define (bytevector-pointer-ref bv index endian)
   (let ((i (if (= size-of-pointer 4)
-	       (bytevector-u32-ref bv index endian)
-	       (bytevector-u64-ref bv index endian))))
+               (bytevector-u32-ref bv index endian)
+               (bytevector-u64-ref bv index endian))))
     (%integer->pointer i)))
 (define (pointer-ref-c-pointer p offset)
   (bytevector-pointer-ref (pointer-bytevector p) offset (native-endianness)))
 (define (pointer-set-c-pointer! p offset ptr)
   (let ((src-p (pointer-memory ptr)))
     (if (= size-of-pointer 8)
-	(pointer-set-c-uint64! p offset (pointer->integer src-p))
-	(pointer-set-c-uint32! p offset (pointer->integer src-p)))))
+        (pointer-set-c-uint64! p offset (pointer->integer src-p))
+        (pointer-set-c-uint32! p offset (pointer->integer src-p)))))
 
 (define (%pointer->integer ptr)
   (pointer->integer (pointer-memory ptr)))
 (define (%integer->pointer i)
-  (define (integer->pointer-bv p) 
+  (define (integer->pointer-bv p)
     (uint-list->bytevector (list p)
-			   (native-endianness) size-of-pointer))
+                           (native-endianness) size-of-pointer))
   (let ((p (integer->pointer i)))
     (make-pointer-wrapper (integer->pointer-bv i) p)))
 

--- a/src/pffi/misc.chezscheme.sls
+++ b/src/pffi/misc.chezscheme.sls
@@ -1,20 +1,20 @@
 ;;; -*- mode:scheme; coding: utf-8; -*-
 ;;;
 ;;; src/pffi/misc.sls - Misc for Chez Scheme
-;;;  
+;;;
 ;;;   Copyright (c) 2018  Takashi Kato  <ktakashi@ymail.com>
-;;;   
+;;;
 ;;;   Redistribution and use in source and binary forms, with or without
 ;;;   modification, are permitted provided that the following conditions
 ;;;   are met:
-;;;   
+;;;
 ;;;   1. Redistributions of source code must retain the above copyright
 ;;;      notice, this list of conditions and the following disclaimer.
-;;;  
+;;;
 ;;;   2. Redistributions in binary form must reproduce the above copyright
 ;;;      notice, this list of conditions and the following disclaimer in the
 ;;;      documentation and/or other materials provided with the distribution.
-;;;  
+;;;
 ;;;   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
 ;;;   "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
 ;;;   LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
@@ -26,12 +26,12 @@
 ;;;   LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
 ;;;   NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 ;;;   SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-;;;  
+;;;
 
 (library (pffi misc)
     (export string-map take drop split-at)
     (import (rnrs)
-	    (only (chezscheme) reverse!))
+            (only (chezscheme) reverse!))
 ;; this is good enough
 (define (string-map proc s) (list->string (map proc (string->list s))))
 
@@ -48,7 +48,7 @@
 (define (split-at x k)
   (let recur ((lis x) (k k) (r '()))
     (cond ((zero? k) (values (reverse! r) lis))
-	  ((null? lis) (error 'split-at "given list it too short"))
-	  (else (recur (cdr lis) (- k 1) (cons (car lis) r))))))
+          ((null? lis) (error 'split-at "given list it too short"))
+          (else (recur (cdr lis) (- k 1) (cons (car lis) r))))))
 
 )

--- a/src/pffi/misc.sls
+++ b/src/pffi/misc.sls
@@ -1,20 +1,20 @@
 ;;; -*- mode:scheme; coding: utf-8; -*-
 ;;;
 ;;; src/pffi/misc.sls - Misc
-;;;  
+;;;
 ;;;   Copyright (c) 2018  Takashi Kato  <ktakashi@ymail.com>
-;;;   
+;;;
 ;;;   Redistribution and use in source and binary forms, with or without
 ;;;   modification, are permitted provided that the following conditions
 ;;;   are met:
-;;;   
+;;;
 ;;;   1. Redistributions of source code must retain the above copyright
 ;;;      notice, this list of conditions and the following disclaimer.
-;;;  
+;;;
 ;;;   2. Redistributions in binary form must reproduce the above copyright
 ;;;      notice, this list of conditions and the following disclaimer in the
 ;;;      documentation and/or other materials provided with the distribution.
-;;;  
+;;;
 ;;;   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
 ;;;   "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
 ;;;   LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
@@ -26,9 +26,9 @@
 ;;;   LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
 ;;;   NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 ;;;   SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-;;;  
+;;;
 
 (library (pffi misc)
     (export string-map take drop split-at)
     (import (only (srfi :13) string-map)
-	    (only (srfi :1) take drop split-at)))
+            (only (srfi :1) take drop split-at)))

--- a/src/pffi/pointers.sls
+++ b/src/pffi/pointers.sls
@@ -1,20 +1,20 @@
 ;;; -*- mode:scheme; coding: utf-8; -*-
 ;;;
 ;;; src/pffi/pointers.sls - Pointer operations
-;;;  
+;;;
 ;;;   Copyright (c) 2015  Takashi Kato  <ktakashi@ymail.com>
-;;;   
+;;;
 ;;;   Redistribution and use in source and binary forms, with or without
 ;;;   modification, are permitted provided that the following conditions
 ;;;   are met:
-;;;   
+;;;
 ;;;   1. Redistributions of source code must retain the above copyright
 ;;;      notice, this list of conditions and the following disclaimer.
-;;;  
+;;;
 ;;;   2. Redistributions in binary form must reproduce the above copyright
 ;;;      notice, this list of conditions and the following disclaimer in the
 ;;;      documentation and/or other materials provided with the distribution.
-;;;  
+;;;
 ;;;   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
 ;;;   "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
 ;;;   LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
@@ -26,55 +26,55 @@
 ;;;   LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
 ;;;   NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 ;;;   SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-;;;  
+;;;
 
 #!r6rs
 
 (library (pffi pointers)
     (export pointer?
-	    bytevector->pointer
-	    pointer->bytevector
-	    pointer->integer
-	    integer->pointer
-	    ;; pointer ref
-	    pointer-ref-c-uint8
-	    pointer-ref-c-int8
-	    pointer-ref-c-uint16
-	    pointer-ref-c-int16
-	    pointer-ref-c-uint32
-	    pointer-ref-c-int32
-	    pointer-ref-c-uint64
-	    pointer-ref-c-int64
-	    pointer-ref-c-unsigned-char
-	    pointer-ref-c-char
-	    pointer-ref-c-unsigned-short
-	    pointer-ref-c-short
-	    pointer-ref-c-unsigned-int
-	    pointer-ref-c-int
-	    pointer-ref-c-unsigned-long
-	    pointer-ref-c-long
-	    pointer-ref-c-float
-	    pointer-ref-c-double
-	    pointer-ref-c-pointer
+            bytevector->pointer
+            pointer->bytevector
+            pointer->integer
+            integer->pointer
+            ;; pointer ref
+            pointer-ref-c-uint8
+            pointer-ref-c-int8
+            pointer-ref-c-uint16
+            pointer-ref-c-int16
+            pointer-ref-c-uint32
+            pointer-ref-c-int32
+            pointer-ref-c-uint64
+            pointer-ref-c-int64
+            pointer-ref-c-unsigned-char
+            pointer-ref-c-char
+            pointer-ref-c-unsigned-short
+            pointer-ref-c-short
+            pointer-ref-c-unsigned-int
+            pointer-ref-c-int
+            pointer-ref-c-unsigned-long
+            pointer-ref-c-long
+            pointer-ref-c-float
+            pointer-ref-c-double
+            pointer-ref-c-pointer
 
-	    ;; pointer set
-	    pointer-set-c-uint8!
-	    pointer-set-c-int8!
-	    pointer-set-c-uint16!
-	    pointer-set-c-int16!
-	    pointer-set-c-uint32!
-	    pointer-set-c-int32!
-	    pointer-set-c-uint64!
-	    pointer-set-c-int64!
-	    pointer-set-c-unsigned-char!
-	    pointer-set-c-char!
-	    pointer-set-c-unsigned-short!
-	    pointer-set-c-short!
-	    pointer-set-c-unsigned-int!
-	    pointer-set-c-int!
-	    pointer-set-c-unsigned-long!
-	    pointer-set-c-long!
-	    pointer-set-c-float!
-	    pointer-set-c-double!
-	    pointer-set-c-pointer!)
+            ;; pointer set
+            pointer-set-c-uint8!
+            pointer-set-c-int8!
+            pointer-set-c-uint16!
+            pointer-set-c-int16!
+            pointer-set-c-uint32!
+            pointer-set-c-int32!
+            pointer-set-c-uint64!
+            pointer-set-c-int64!
+            pointer-set-c-unsigned-char!
+            pointer-set-c-char!
+            pointer-set-c-unsigned-short!
+            pointer-set-c-short!
+            pointer-set-c-unsigned-int!
+            pointer-set-c-int!
+            pointer-set-c-unsigned-long!
+            pointer-set-c-long!
+            pointer-set-c-float!
+            pointer-set-c-double!
+            pointer-set-c-pointer!)
     (import (pffi compat)))

--- a/src/pffi/procedure.sls
+++ b/src/pffi/procedure.sls
@@ -1,20 +1,20 @@
 ;;; -*- mode:scheme; coding: utf-8; -*-
 ;;;
 ;;; src/pffi/procedure.sls - FFI Procedure
-;;;  
+;;;
 ;;;   Copyright (c) 2015  Takashi Kato  <ktakashi@ymail.com>
-;;;   
+;;;
 ;;;   Redistribution and use in source and binary forms, with or without
 ;;;   modification, are permitted provided that the following conditions
 ;;;   are met:
-;;;   
+;;;
 ;;;   1. Redistributions of source code must retain the above copyright
 ;;;      notice, this list of conditions and the following disclaimer.
-;;;  
+;;;
 ;;;   2. Redistributions in binary form must reproduce the above copyright
 ;;;      notice, this list of conditions and the following disclaimer in the
 ;;;      documentation and/or other materials provided with the distribution.
-;;;  
+;;;
 ;;;   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
 ;;;   "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
 ;;;   LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
@@ -26,45 +26,45 @@
 ;;;   LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
 ;;;   NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 ;;;   SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-;;;  
+;;;
 
 #!r6rs
 (library (pffi procedure)
     (export foreign-procedure
-	    c-callback
-	    free-c-callback
-	    open-shared-object
-	    lookup-shared-object
+            c-callback
+            free-c-callback
+            open-shared-object
+            lookup-shared-object
 
-	    ;; primitive types
-	    ;; maybe these should be exported from
-	    ;; different library
-	    char  unsigned-char
-	    short unsigned-short
-	    int   unsigned-int
-	    long  unsigned-long
-	    float double
-	    int8_t  uint8_t
-	    int16_t uint16_t
-	    int32_t uint32_t
-	    int64_t uint64_t
-	    pointer callback
-	    void
+            ;; primitive types
+            ;; maybe these should be exported from
+            ;; different library
+            char  unsigned-char
+            short unsigned-short
+            int   unsigned-int
+            long  unsigned-long
+            float double
+            int8_t  uint8_t
+            int16_t uint16_t
+            int32_t uint32_t
+            int64_t uint64_t
+            pointer callback
+            void
 
-	    size-of-char
-	    size-of-short
-	    size-of-int
-	    size-of-long
-	    size-of-float
-	    size-of-double
-	    size-of-pointer
-	    size-of-int8_t
-	    size-of-int16_t
-	    size-of-int32_t
-	    size-of-int64_t
-	    )
+            size-of-char
+            size-of-short
+            size-of-int
+            size-of-long
+            size-of-float
+            size-of-double
+            size-of-pointer
+            size-of-int8_t
+            size-of-int16_t
+            size-of-int32_t
+            size-of-int64_t
+            )
     (import (rnrs)
-	    (pffi compat))
+            (pffi compat))
 
 (define-syntax foreign-procedure
   (syntax-rules ()
@@ -76,7 +76,7 @@
     (syntax-case x (lambda)
       ((k ret ((type var) ...) (lambda (formals ...) body1 body ...))
        (or (for-all bound-identifier=? #'(var ...) #'(formals ...))
-	   (syntax-violation 'c-callback "invalid declaration" '#'x))
+           (syntax-violation 'c-callback "invalid declaration" '#'x))
        #'(k ret (type ...) (lambda (var ...) body1 body ...)))
       ((_ ret (args ...) proc)
        #'(make-c-callback ret (list args ...) proc)))))

--- a/src/pffi/struct.sls
+++ b/src/pffi/struct.sls
@@ -1,20 +1,20 @@
 ;;; -*- mode:scheme; coding: utf-8; -*-
 ;;;
 ;;; src/pffi/struct.sls - Foreign structure
-;;;  
+;;;
 ;;;   Copyright (c) 2015-2019  Takashi Kato  <ktakashi@ymail.com>
-;;;   
+;;;
 ;;;   Redistribution and use in source and binary forms, with or without
 ;;;   modification, are permitted provided that the following conditions
 ;;;   are met:
-;;;   
+;;;
 ;;;   1. Redistributions of source code must retain the above copyright
 ;;;      notice, this list of conditions and the following disclaimer.
-;;;  
+;;;
 ;;;   2. Redistributions in binary form must reproduce the above copyright
 ;;;      notice, this list of conditions and the following disclaimer in the
 ;;;      documentation and/or other materials provided with the distribution.
-;;;  
+;;;
 ;;;   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
 ;;;   "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
 ;;;   LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
@@ -26,7 +26,7 @@
 ;;;   LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
 ;;;   NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 ;;;   SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-;;;  
+;;;
 
 #!r6rs
 
@@ -38,10 +38,10 @@
 
 (library (pffi struct)
     (export define-foreign-struct
-	    define-foreign-union)
+            define-foreign-union)
     (import (rnrs)
-	    (pffi compat)
-	    (only (pffi misc) take drop split-at))
+            (pffi compat)
+            (only (pffi misc) take drop split-at))
 
 ;; use fields, protocol and parent from (rnrs)
 ;; e.g.
@@ -56,317 +56,317 @@
   (lambda (x)
     (define (->ctr&pred name)
       (let ((base (symbol->string (syntax->datum name))))
-	(list (string->symbol (string-append "make-" base))
-	      (string->symbol (string-append base "?")))))
+        (list (string->symbol (string-append "make-" base))
+              (string->symbol (string-append base "?")))))
     (define (process-clauses struct-name clauses)
       (define sname (symbol->string (syntax->datum struct-name)))
       (define d syntax->datum)
       (define (process-fields fields)
-	(define (ref name)
-	  (string->symbol 
-	   (string-append sname "-" (symbol->string (syntax->datum name)))))
-	(define (set name)
-	  (string->symbol 
-	   (string-append sname "-" (symbol->string (syntax->datum name))
-			  "-set!")))
-	(let loop ((fields fields) (r '()))
-	  (syntax-case fields ()
-	    (() (reverse r))
-	    (((type name) . rest)
-	     (loop #'rest 
-		   (cons (list (d #'type) (d  #'name)
-			       (ref #'name) (set #'name)) r)))
-	    (((type name ref) . rest)
-	     (loop #'rest 
-		   (cons (list (d #'type) (d #'name) (d #'ref)
-			       (set #'name)) r)))
-	    (((type name ref set) . rest)
-	     (loop #'rest
-		   (cons (list (d #'type) (d #'name) (d #'ref) (d #'set))
-			 r))))))
+        (define (ref name)
+          (string->symbol
+           (string-append sname "-" (symbol->string (syntax->datum name)))))
+        (define (set name)
+          (string->symbol
+           (string-append sname "-" (symbol->string (syntax->datum name))
+                          "-set!")))
+        (let loop ((fields fields) (r '()))
+          (syntax-case fields ()
+            (() (reverse r))
+            (((type name) . rest)
+             (loop #'rest
+                   (cons (list (d #'type) (d  #'name)
+                               (ref #'name) (set #'name)) r)))
+            (((type name ref) . rest)
+             (loop #'rest
+                   (cons (list (d #'type) (d #'name) (d #'ref)
+                               (set #'name)) r)))
+            (((type name ref set) . rest)
+             (loop #'rest
+                   (cons (list (d #'type) (d #'name) (d #'ref) (d #'set))
+                         r))))))
       (let loop ((clauses clauses) (fs #f) (par #f) (proto #f) (align #f))
-	(syntax-case clauses (fields parent protocol)
-	  (() (list fs par proto align))
-	  (((fields defs ...) . rest)
-	   (or (not fs)
-	       (syntax-violation 'define-foreign-struct 
-				 "only one fields clause allowed" 
-				 x clauses))
-	   (loop #'rest (process-fields #'(defs ...)) par proto align))
-	  (((parent p) . rest)
-	   (or (not par)
-	       (syntax-violation 'define-foreign-struct 
-				 "only one parent clause allowed" 
-				 x clauses))
-	   (loop #'rest fs (d #'p) proto align))
-	  (((protocol p) . rest)
-	   (or (not proto)
-	       (syntax-violation 'define-foreign-struct 
-				 "only one protocol clause allowed" 
-				 x clauses))
-	   (loop #'rest fs par (d #'p) align))
-	  (((alignment a) . rest)
-	   (or (not align)
-	       (syntax-violation 'define-foreign-struct 
-				 "only one alignment clause allowed" 
-				 x clauses))
-	   (loop #'rest fs par proto #'a))
-	  (_ (syntax-violation 'define-foreign-struct
-			       "invalid define-foreign-struct" x clauses)))))
+        (syntax-case clauses (fields parent protocol)
+          (() (list fs par proto align))
+          (((fields defs ...) . rest)
+           (or (not fs)
+               (syntax-violation 'define-foreign-struct
+                                 "only one fields clause allowed"
+                                 x clauses))
+           (loop #'rest (process-fields #'(defs ...)) par proto align))
+          (((parent p) . rest)
+           (or (not par)
+               (syntax-violation 'define-foreign-struct
+                                 "only one parent clause allowed"
+                                 x clauses))
+           (loop #'rest fs (d #'p) proto align))
+          (((protocol p) . rest)
+           (or (not proto)
+               (syntax-violation 'define-foreign-struct
+                                 "only one protocol clause allowed"
+                                 x clauses))
+           (loop #'rest fs par (d #'p) align))
+          (((alignment a) . rest)
+           (or (not align)
+               (syntax-violation 'define-foreign-struct
+                                 "only one alignment clause allowed"
+                                 x clauses))
+           (loop #'rest fs par proto #'a))
+          (_ (syntax-violation 'define-foreign-struct
+                               "invalid define-foreign-struct" x clauses)))))
 
     (define (->sizeof type)
       (string->symbol (string-append "size-of-"
-				     (symbol->string (syntax->datum type)))))
+                                     (symbol->string (syntax->datum type)))))
     (define (->sizeofs types)
       (let loop ((types types) (r '()))
-	(syntax-case types ()
-	  (() (reverse r))
-	  ((a . d) (loop #'d (cons (list (syntax->datum #'a) 
-					 (->sizeof #'a)) r))))))
+        (syntax-case types ()
+          (() (reverse r))
+          ((a . d) (loop #'d (cons (list (syntax->datum #'a)
+                                         (->sizeof #'a)) r))))))
 
     (syntax-case x ()
       ((k (name ctr pred) specs ...)
        (and (identifier? #'name) (identifier? #'ctr) (identifier? #'pred))
        ;; collect fields, parent and protocol
        (with-syntax (((((type field ref set) ...) parent protocol align)
-		      (datum->syntax #'k (process-clauses #'name 
-							  #'(specs ...))))
-		     (sizeof (datum->syntax #'k (->sizeof #'name)))
-		     ;; To avoid Guile's bug.
-		     ;; this isn't needed if macro expander works *properly*
-		     ((this-protocol) (generate-temporaries '(this-protocol))))
-	 (with-syntax ((((types sizeofs) ...) 
-			(datum->syntax #'k (->sizeofs #'(type ...)))))
-	   #'(begin
-	       (define alignment-check
-		 (unless (or (not align) (memv align '(1 2 4 8 16)))
-		   (assertion-violation 'define-foreign-struct
-					"alignment must be  1, 2, 4, 8, or 16"
-					align)))
-	       (define sizeof (compute-size parent
-					    (list (cons type sizeofs) ...)
-					    align))
-	       (define this-protocol protocol) 
-	       (define name 
-		 (make-foreign-struct-descriptor 
-		  'name
-		  sizeof
-		  (struct-alignment (list (cons type sizeofs) ...))
-		  (list (cons* 'field types sizeofs) ...)
-		  parent
-		  (if this-protocol #t #f)
-		  ;; type-ref
-		  (lambda (o offset)
-		    (let ((bv (make-bytevector sizeof)))
-		      (bytevector-copy! o offset bv 0 sizeof)
-		      bv))
-		  ;; type-set!
-		  (lambda (o offset v)
-		    (bytevector-copy! v 0 o offset sizeof))))
-	       
-	       ;; TODO sub struct
-	       (define (pred o) 
-		 (and (bytevector? o) 
-		      (>= (bytevector-length o) sizeof)))
-	       ;; TODO handle protocol
-	       (define ctr (make-constructor name this-protocol))
-	       (define ref
-		 (let ((acc (type->ref type))
-		       (offset (compute-offset name 'field align)))
-		   (lambda (o) (acc o offset))))
-	       ...
-	       (define set
-		 (let ((acc (type->set! type))
-		       (offset (compute-offset name 'field align)))
-		   (lambda (o v) (acc o offset v))))
-	       ...
-	       ;; ugly...
-	       (define dummy 
-		 (begin
-		   (foreign-struct-descriptor-getters-set! name (list ref ...))
-		   (foreign-struct-descriptor-setters-set! name (list set ...))
-		   (foreign-struct-descriptor-ctr-set! name ctr)
-		   (foreign-struct-descriptor-protocol-set! name 
-		    (or this-protocol (default-protocol name)))))
-	       )
-	   )))
+                      (datum->syntax #'k (process-clauses #'name
+                                                          #'(specs ...))))
+                     (sizeof (datum->syntax #'k (->sizeof #'name)))
+                     ;; To avoid Guile's bug.
+                     ;; this isn't needed if macro expander works *properly*
+                     ((this-protocol) (generate-temporaries '(this-protocol))))
+         (with-syntax ((((types sizeofs) ...)
+                        (datum->syntax #'k (->sizeofs #'(type ...)))))
+           #'(begin
+               (define alignment-check
+                 (unless (or (not align) (memv align '(1 2 4 8 16)))
+                   (assertion-violation 'define-foreign-struct
+                                        "alignment must be  1, 2, 4, 8, or 16"
+                                        align)))
+               (define sizeof (compute-size parent
+                                            (list (cons type sizeofs) ...)
+                                            align))
+               (define this-protocol protocol)
+               (define name
+                 (make-foreign-struct-descriptor
+                  'name
+                  sizeof
+                  (struct-alignment (list (cons type sizeofs) ...))
+                  (list (cons* 'field types sizeofs) ...)
+                  parent
+                  (if this-protocol #t #f)
+                  ;; type-ref
+                  (lambda (o offset)
+                    (let ((bv (make-bytevector sizeof)))
+                      (bytevector-copy! o offset bv 0 sizeof)
+                      bv))
+                  ;; type-set!
+                  (lambda (o offset v)
+                    (bytevector-copy! v 0 o offset sizeof))))
+
+               ;; TODO sub struct
+               (define (pred o)
+                 (and (bytevector? o)
+                      (>= (bytevector-length o) sizeof)))
+               ;; TODO handle protocol
+               (define ctr (make-constructor name this-protocol))
+               (define ref
+                 (let ((acc (type->ref type))
+                       (offset (compute-offset name 'field align)))
+                   (lambda (o) (acc o offset))))
+               ...
+               (define set
+                 (let ((acc (type->set! type))
+                       (offset (compute-offset name 'field align)))
+                   (lambda (o v) (acc o offset v))))
+               ...
+               ;; ugly...
+               (define dummy
+                 (begin
+                   (foreign-struct-descriptor-getters-set! name (list ref ...))
+                   (foreign-struct-descriptor-setters-set! name (list set ...))
+                   (foreign-struct-descriptor-ctr-set! name ctr)
+                   (foreign-struct-descriptor-protocol-set! name
+                    (or this-protocol (default-protocol name)))))
+               )
+           )))
       ((k name specs ...)
        (identifier? #'name)
        (with-syntax (((ctr pred) (datum->syntax #'k (->ctr&pred #'name))))
-	 #'(k (name ctr pred) specs ...))))))
+         #'(k (name ctr pred) specs ...))))))
 
 (define-syntax define-foreign-union
   (lambda (x)
     (define (->ctr&pred name)
       (let ((base (symbol->string (syntax->datum name))))
-	(list (string->symbol (string-append "make-" base))
-	      (string->symbol (string-append base "?")))))
+        (list (string->symbol (string-append "make-" base))
+              (string->symbol (string-append base "?")))))
     (define (process-clauses struct-name clauses)
       (define sname (symbol->string (syntax->datum struct-name)))
       (define d syntax->datum)
       (define (process-fields fields)
-	(define (ref name)
-	  (string->symbol 
-	   (string-append sname "-" (symbol->string (syntax->datum name)))))
-	(define (set name)
-	  (string->symbol 
-	   (string-append sname "-" (symbol->string (syntax->datum name))
-			  "-set!")))
-	(let loop ((fields fields) (r '()))
-	  (syntax-case fields ()
-	    (() (reverse r))
-	    (((type name) . rest)
-	     (loop #'rest 
-		   (cons (list (d #'type) (d  #'name)
-			       (ref #'name) (set #'name)) r)))
-	    (((type name ref) . rest)
-	     (loop #'rest 
-		   (cons (list (d #'type) (d #'name) (d #'ref)
-			       (set #'name)) r)))
-	    (((type name ref set) . rest)
-	     (loop #'rest
-		   (cons (list (d #'type) (d #'name) (d #'ref) (d #'set))
-			 r))))))
+        (define (ref name)
+          (string->symbol
+           (string-append sname "-" (symbol->string (syntax->datum name)))))
+        (define (set name)
+          (string->symbol
+           (string-append sname "-" (symbol->string (syntax->datum name))
+                          "-set!")))
+        (let loop ((fields fields) (r '()))
+          (syntax-case fields ()
+            (() (reverse r))
+            (((type name) . rest)
+             (loop #'rest
+                   (cons (list (d #'type) (d  #'name)
+                               (ref #'name) (set #'name)) r)))
+            (((type name ref) . rest)
+             (loop #'rest
+                   (cons (list (d #'type) (d #'name) (d #'ref)
+                               (set #'name)) r)))
+            (((type name ref set) . rest)
+             (loop #'rest
+                   (cons (list (d #'type) (d #'name) (d #'ref) (d #'set))
+                         r))))))
       (let loop ((clauses clauses) (fs #f) (proto #f))
-	(syntax-case clauses (fields protocol)
-	  (() (list fs proto))
-	  (((fields defs ...) . rest)
-	   (or (not fs)
-	       (syntax-violation 'define-foreign-struct 
-				 "only one fields clause allowed" 
-				 x clauses))
-	   (loop #'rest (process-fields #'(defs ...)) proto))
-	  (((protocol p) . rest)
-	   (or (not proto)
-	       (syntax-violation 'define-foreign-struct 
-				 "only one protocol clause allowed" 
-				 x clauses))
-	   (loop #'rest fs (d #'p)))
-	  (_ (syntax-violation 'define-foreign-struct
-			       "invalid define-foreign-struct" x clauses)))))
+        (syntax-case clauses (fields protocol)
+          (() (list fs proto))
+          (((fields defs ...) . rest)
+           (or (not fs)
+               (syntax-violation 'define-foreign-struct
+                                 "only one fields clause allowed"
+                                 x clauses))
+           (loop #'rest (process-fields #'(defs ...)) proto))
+          (((protocol p) . rest)
+           (or (not proto)
+               (syntax-violation 'define-foreign-struct
+                                 "only one protocol clause allowed"
+                                 x clauses))
+           (loop #'rest fs (d #'p)))
+          (_ (syntax-violation 'define-foreign-struct
+                               "invalid define-foreign-struct" x clauses)))))
 
     (define (->sizeof type)
       (string->symbol (string-append "size-of-"
-				     (symbol->string (syntax->datum type)))))
+                                     (symbol->string (syntax->datum type)))))
     (define (->sizeofs types)
       (let loop ((types types) (r '()))
-	(syntax-case types ()
-	  (() (reverse r))
-	  ((a . d) (loop #'d (cons (list (syntax->datum #'a) 
-					 (->sizeof #'a)) r))))))
+        (syntax-case types ()
+          (() (reverse r))
+          ((a . d) (loop #'d (cons (list (syntax->datum #'a)
+                                         (->sizeof #'a)) r))))))
 
     (syntax-case x ()
       ((k (name ctr pred) specs ...)
        (and (identifier? #'name) (identifier? #'ctr) (identifier? #'pred))
        ;; collect fields, parent and protocol
        (with-syntax (((((type field ref set) ...) protocol)
-		      (datum->syntax #'k (process-clauses #'name 
-							  #'(specs ...))))
-		     (sizeof (datum->syntax #'k (->sizeof #'name)))
-		     ;; To avoid Guile's bug.
-		     ;; this isn't needed if macro expander works *properly*
-		     ((this-protocol) (generate-temporaries '(this-protocol))))
-	 (with-syntax ((((types sizeofs) ...) 
-			(datum->syntax #'k (->sizeofs #'(type ...)))))
-	   #'(begin
-	       (define sizeof
-		 ;; the same as alignment :)
-		 (struct-alignment (list (cons type sizeofs) ...)))
-	       (define this-protocol protocol)
-	       (define name 
-		 (make-foreign-struct-descriptor 
-		  'name
-		  sizeof
-		  (struct-alignment (list (cons type sizeofs) ...))
-		  ;; only one field so dummy
-		  (list (cons* 'dummy 'name sizeof))
-		  #f
-		  (if this-protocol #t #f)
-		  ;; type-ref
-		  (lambda (o offset)
-		    (let ((bv (make-bytevector sizeof)))
-		      (bytevector-copy! o offset bv 0 sizeof)
-		      bv))
-		  ;; type-set!
-		  (lambda (o offset v)
-		    (bytevector-copy! v 0 o offset sizeof))))
-	       ;; sub struct
-	       (define (pred o) 
-		 (and (bytevector? o) 
-		      (>= (bytevector-length o) sizeof)))
-	       (define ctr
-		 (let ()
-		   (define fields '(field ...))
-		   (define (custom-ctr . field&value)
-		     (define f
-		       (and (not (null? field&value)) (car field&value)))
-		     (define v
-		       (and (not (null? field&value))
-			    (not (null? (cdr field&value)))
-			    (cadr field&value)))
-		     (define setters
-		       (foreign-struct-descriptor-setters name))
-		     (let ((r (make-bytevector sizeof 0)))
-		       ;; a bit inefficient...
-		       (when (and f v)
-			 (do ((i 0 (+ i 1)) (f* fields (cdr f*)))
-			     ((or (null? f*) (eq? (car f*) f))
-			      (unless (null? f*)
-				(let ((s (list-ref setters i)))
-				  (s r v))))))
-		       r))
-		   (if this-protocol
-		       (this-protocol custom-ctr)
-		       (lambda () (make-bytevector sizeof 0)))))
-	       (define ref
-		 (let ((acc (type->ref type)))
-		   (lambda (o) (acc o 0))))
-	       ...
-	       (define set
-		 (let ((acc (type->set! type)))
-		   (lambda (o v) (acc o 0 v))))
-	       ...
-	       ;; ugly...
-	       (define dummy 
-		 (begin
-		   (foreign-struct-descriptor-getters-set! name (list ref ...))
-		   (foreign-struct-descriptor-setters-set! name (list set ...))
-		   (foreign-struct-descriptor-ctr-set! name ctr)
-		   (foreign-struct-descriptor-protocol-set! name 
-		    (or this-protocol (default-protocol name)))))
-	       )
-	   )))
+                      (datum->syntax #'k (process-clauses #'name
+                                                          #'(specs ...))))
+                     (sizeof (datum->syntax #'k (->sizeof #'name)))
+                     ;; To avoid Guile's bug.
+                     ;; this isn't needed if macro expander works *properly*
+                     ((this-protocol) (generate-temporaries '(this-protocol))))
+         (with-syntax ((((types sizeofs) ...)
+                        (datum->syntax #'k (->sizeofs #'(type ...)))))
+           #'(begin
+               (define sizeof
+                 ;; the same as alignment :)
+                 (struct-alignment (list (cons type sizeofs) ...)))
+               (define this-protocol protocol)
+               (define name
+                 (make-foreign-struct-descriptor
+                  'name
+                  sizeof
+                  (struct-alignment (list (cons type sizeofs) ...))
+                  ;; only one field so dummy
+                  (list (cons* 'dummy 'name sizeof))
+                  #f
+                  (if this-protocol #t #f)
+                  ;; type-ref
+                  (lambda (o offset)
+                    (let ((bv (make-bytevector sizeof)))
+                      (bytevector-copy! o offset bv 0 sizeof)
+                      bv))
+                  ;; type-set!
+                  (lambda (o offset v)
+                    (bytevector-copy! v 0 o offset sizeof))))
+               ;; sub struct
+               (define (pred o)
+                 (and (bytevector? o)
+                      (>= (bytevector-length o) sizeof)))
+               (define ctr
+                 (let ()
+                   (define fields '(field ...))
+                   (define (custom-ctr . field&value)
+                     (define f
+                       (and (not (null? field&value)) (car field&value)))
+                     (define v
+                       (and (not (null? field&value))
+                            (not (null? (cdr field&value)))
+                            (cadr field&value)))
+                     (define setters
+                       (foreign-struct-descriptor-setters name))
+                     (let ((r (make-bytevector sizeof 0)))
+                       ;; a bit inefficient...
+                       (when (and f v)
+                         (do ((i 0 (+ i 1)) (f* fields (cdr f*)))
+                             ((or (null? f*) (eq? (car f*) f))
+                              (unless (null? f*)
+                                (let ((s (list-ref setters i)))
+                                  (s r v))))))
+                       r))
+                   (if this-protocol
+                       (this-protocol custom-ctr)
+                       (lambda () (make-bytevector sizeof 0)))))
+               (define ref
+                 (let ((acc (type->ref type)))
+                   (lambda (o) (acc o 0))))
+               ...
+               (define set
+                 (let ((acc (type->set! type)))
+                   (lambda (o v) (acc o 0 v))))
+               ...
+               ;; ugly...
+               (define dummy
+                 (begin
+                   (foreign-struct-descriptor-getters-set! name (list ref ...))
+                   (foreign-struct-descriptor-setters-set! name (list set ...))
+                   (foreign-struct-descriptor-ctr-set! name ctr)
+                   (foreign-struct-descriptor-protocol-set! name
+                    (or this-protocol (default-protocol name)))))
+               )
+           )))
       ((k name specs ...)
        (identifier? #'name)
        (with-syntax (((ctr pred) (datum->syntax #'k (->ctr&pred #'name))))
-	 #'(k (name ctr pred) specs ...))))))
+         #'(k (name ctr pred) specs ...))))))
 
 
 (define (total-field-count desc)
   (let loop ((desc desc) (r 0))
     (if desc
-	(loop (foreign-struct-descriptor-parent desc)
-	      (+ (length (foreign-struct-descriptor-fields desc)) r))
-	r)))
+        (loop (foreign-struct-descriptor-parent desc)
+              (+ (length (foreign-struct-descriptor-fields desc)) r))
+        r)))
 
 (define (make-struct desc field-values)
   (define (set-parent-fields desc bv field-values)
     (define (->ordered-paretns desc)
       (let loop ((p (foreign-struct-descriptor-parent desc)) (r '()))
-	(if p
-	    (loop (foreign-struct-descriptor-parent p) (cons p r))
-	    (reverse r))))
+        (if p
+            (loop (foreign-struct-descriptor-parent p) (cons p r))
+            (reverse r))))
     (let loop ((parents (->ordered-paretns desc))
-	       (field-values field-values))
+               (field-values field-values))
       (if (null? parents)
-	  field-values
-	  (let* ((setters (foreign-struct-descriptor-setters (car parents)))
-		 (len (length setters)))
-	    (for-each (lambda (set arg) (set bv arg)) 
-		      setters (take field-values len))
-	    (loop (cdr parents) (drop field-values len))))))
+          field-values
+          (let* ((setters (foreign-struct-descriptor-setters (car parents)))
+                 (len (length setters)))
+            (for-each (lambda (set arg) (set bv arg))
+                      setters (take field-values len))
+            (loop (cdr parents) (drop field-values len))))))
   (let ((setters (foreign-struct-descriptor-setters desc))
-	(bv (make-bytevector (foreign-struct-descriptor-size desc))))
+        (bv (make-bytevector (foreign-struct-descriptor-size desc))))
     (let ((field-values (set-parent-fields desc bv field-values)))
       (for-each (lambda (set arg) (set bv arg)) setters field-values)
       bv)))
@@ -375,110 +375,110 @@
   (protocol
    (lambda field-values
      (if (= (length field-values) argc)
-	 (make-struct desc field-values)
-	 (assertion-violation "struct constructor"
-			      "wrong number of arguments"
-			      field-values)))))
+         (make-struct desc field-values)
+         (assertion-violation "struct constructor"
+                              "wrong number of arguments"
+                              field-values)))))
 
 (define (make-nested-conser protocol odesc argc)
   (protocol
    ((let loop ((desc odesc))
       (cond ((foreign-struct-descriptor-parent desc)
-	     => (lambda (parent)
-		  (lambda extra-field-values
-		    (lambda protocol-args
-		      (lambda this-field-values
-			(apply ((foreign-struct-descriptor-protocol parent)
-				(apply (loop parent)
-				       (append this-field-values
-					       extra-field-values)))
-			       protocol-args))))))
-	    (else
-	     (lambda extra-field-values
-	       (lambda this-field-values
-		 (let ((field-values (append this-field-values
-					     extra-field-values)))
-		   (if (= (length field-values) argc)
-		       (make-struct odesc field-values)
-		       (assertion-violation "struct constructor"
-					    "wrong number of arguments"
-					    field-values)))))))))))
+             => (lambda (parent)
+                  (lambda extra-field-values
+                    (lambda protocol-args
+                      (lambda this-field-values
+                        (apply ((foreign-struct-descriptor-protocol parent)
+                                (apply (loop parent)
+                                       (append this-field-values
+                                               extra-field-values)))
+                               protocol-args))))))
+            (else
+             (lambda extra-field-values
+               (lambda this-field-values
+                 (let ((field-values (append this-field-values
+                                             extra-field-values)))
+                   (if (= (length field-values) argc)
+                       (make-struct odesc field-values)
+                       (assertion-violation "struct constructor"
+                                            "wrong number of arguments"
+                                            field-values)))))))))))
 
 (define (default-protocol desc)
   (let ((parent (foreign-struct-descriptor-parent desc)))
     (if parent
-	(let ((parent-field-count (total-field-count parent)))
-	  (lambda (p)
-	    (lambda field-values
-	      (let-values (((parent-field-values this-field-values)
-			    (split-at field-values parent-field-count)))
-		(let ((n (apply p parent-field-values)))
-		  (apply n this-field-values))))))
-	(lambda (p)
-	  (lambda field-values
-	    (apply p field-values))))))
+        (let ((parent-field-count (total-field-count parent)))
+          (lambda (p)
+            (lambda field-values
+              (let-values (((parent-field-values this-field-values)
+                            (split-at field-values parent-field-count)))
+                (let ((n (apply p parent-field-values)))
+                  (apply n this-field-values))))))
+        (lambda (p)
+          (lambda field-values
+            (apply p field-values))))))
 
 ;; TODO implement it properly...
 (define (make-constructor desc protocol)
   (let ((parent? (foreign-struct-descriptor-parent desc))
-	(protocol (or protocol (default-protocol desc))))
+        (protocol (or protocol (default-protocol desc))))
     (if parent?
-	;; check parent protocol
-	(begin
-	  (when (and (foreign-struct-descriptor-has-protocol? parent?)
-		     (not (foreign-struct-descriptor-has-protocol? desc)))
-	    (assertion-violation 'make-constructor 
-				 "parent has custom protocol" desc))
-	  (make-nested-conser protocol desc
-			      (total-field-count desc)))
-	(make-simple-conser protocol desc 
-			    (length (foreign-struct-descriptor-fields desc))))))
+        ;; check parent protocol
+        (begin
+          (when (and (foreign-struct-descriptor-has-protocol? parent?)
+                     (not (foreign-struct-descriptor-has-protocol? desc)))
+            (assertion-violation 'make-constructor
+                                 "parent has custom protocol" desc))
+          (make-nested-conser protocol desc
+                              (total-field-count desc)))
+        (make-simple-conser protocol desc
+                            (length (foreign-struct-descriptor-fields desc))))))
 
 (define (struct-alignment lis)
   (apply max (map (lambda (l)
-		    (if (foreign-struct-descriptor? (car l))
-			(foreign-struct-descriptor-alignment (car l))
-			(cdr l))) lis)))
+                    (if (foreign-struct-descriptor? (car l))
+                        (foreign-struct-descriptor-alignment (car l))
+                        (cdr l))) lis)))
 
 ;; ref
 ;;  http://en.wikipedia.org/wiki/Data_structure_alignment
-(define (compute-size parent list-of-sizeofs alignment) 
+(define (compute-size parent list-of-sizeofs alignment)
   (define-syntax padding
     (syntax-rules ()
       ((_ o a) ;; offset align
        (if (and alignment (zero? (mod o alignment)))
-	   0
-	   (bitwise-and (- o) (- a 1))))))
+           0
+           (bitwise-and (- o) (- a 1))))))
 
   (let ((parent-size (if parent (foreign-struct-descriptor-size parent) 0))
-	(align (if parent (foreign-struct-descriptor-alignment parent) 0)))
+        (align (if parent (foreign-struct-descriptor-alignment parent) 0)))
     ;; assume primitive types have the same alignment as its size
     ;; (according to the Wikipedia page, linix may have different value
     ;;  for double but never seen it)
     ;; struct manages own alignment
-    (let loop ((sizes list-of-sizeofs) 
-	       (max-size align) 
-	       (size parent-size))
+    (let loop ((sizes list-of-sizeofs)
+               (max-size align)
+               (size parent-size))
       (if (null? sizes)
-	  ;; fixup
-	  (let ((m (if alignment (- alignment 1) (- max-size 1))))
-	    (bitwise-and (+ size m) (bitwise-not m)))
-	  (let ((s (car sizes)))
-	    (if (foreign-struct-descriptor? (car s))
-		(let* ((sa (foreign-struct-descriptor-alignment (car s)))
-		       (ss (cdr s))
-		       (size (+ size ss))
-		       (pad (padding size sa)))
-		  (loop (cdr sizes)
-			(if (> sa max-size) sa max-size)
-			(+ size pad)))
-		;; primitive
-		(let* ((ps (cdr s))
-		       (size (+ size ps))
-		       (pad (padding size ps)))
-		  (loop (cdr sizes)
-			(if (> ps max-size) ps max-size)
-			(+ size pad)))))))))
+          ;; fixup
+          (let ((m (if alignment (- alignment 1) (- max-size 1))))
+            (bitwise-and (+ size m) (bitwise-not m)))
+          (let ((s (car sizes)))
+            (if (foreign-struct-descriptor? (car s))
+                (let* ((sa (foreign-struct-descriptor-alignment (car s)))
+                       (ss (cdr s))
+                       (size (+ size ss))
+                       (pad (padding size sa)))
+                  (loop (cdr sizes)
+                        (if (> sa max-size) sa max-size)
+                        (+ size pad)))
+                ;; primitive
+                (let* ((ps (cdr s))
+                       (size (+ size ps))
+                       (pad (padding size ps)))
+                  (loop (cdr sizes)
+                        (if (> ps max-size) ps max-size)
+                        (+ size pad)))))))))
 
 ;; FIXME I'm not sure if I'm doing correctly here but work
 ;;       (tests are passing...)
@@ -487,68 +487,68 @@
     (syntax-rules ()
       ((_ o a) ;; offset align
        (let* ((off o)
-	      (ali (if align align a))
-	      (n (+ off ali)))
-	 (bitwise-and (- n 1) (bitwise-not (- ali 1)))))))
+              (ali (if align align a))
+              (n (+ off ali)))
+         (bitwise-and (- n 1) (bitwise-not (- ali 1)))))))
   (define-syntax padding
     (syntax-rules ()
       ((_ f o a) ;; offset align
        (let ((field f) (ali a) (off o))
-	 (if (and align (zero? (mod off align)))
-	     0
-	     (bitwise-and (- off) (- a 1)))))))
+         (if (and align (zero? (mod off align)))
+             0
+             (bitwise-and (- off) (- a 1)))))))
   (define (compute-next-size size f)
     (let* ((s (cddr f))
-	   (size (+ size s))
-	   (a (if (foreign-struct-descriptor? (cadr f))
-		  (foreign-struct-descriptor-alignment (cadr f))
-		  s))
-	   (pad (padding (cadr f) size a)))
+           (size (+ size s))
+           (a (if (foreign-struct-descriptor? (cadr f))
+                  (foreign-struct-descriptor-alignment (cadr f))
+                  s))
+           (pad (padding (cadr f) size a)))
       (+ size pad)))
   (define parent-align (if (foreign-struct-descriptor-parent descriptor)
-			   (foreign-struct-descriptor-alignment
-			    (foreign-struct-descriptor-parent descriptor))
-			   0))
+                           (foreign-struct-descriptor-alignment
+                            (foreign-struct-descriptor-parent descriptor))
+                           0))
   (define (alignment field)
     (if (foreign-struct-descriptor? (cadr field))
-	(foreign-struct-descriptor-alignment (cadr field))
-	(cddr field)))
-  
+        (foreign-struct-descriptor-alignment (cadr field))
+        (cddr field)))
+
   (let loop ((fields (foreign-struct-descriptor-fields descriptor))
-	     ;; well...
-	     (size (if (foreign-struct-descriptor-parent descriptor)
-		       (foreign-struct-descriptor-size
-			(foreign-struct-descriptor-parent descriptor))
-		       0))
-	     ;; rough next offset
-	     (off (offset 0 parent-align)))
+             ;; well...
+             (size (if (foreign-struct-descriptor-parent descriptor)
+                       (foreign-struct-descriptor-size
+                        (foreign-struct-descriptor-parent descriptor))
+                       0))
+             ;; rough next offset
+             (off (offset 0 parent-align)))
     (if (null? fields)
-	(assertion-violation 'compute-offset "invalid field name" field)
-	(let ((f (car fields)))
-	  (if (eq? field (car f))
-	      (if (foreign-struct-descriptor? (cadr f))
-		  (offset off (foreign-struct-descriptor-alignment (cadr f)))
-		  (let ((next-size (compute-next-size size f)))
-		    (- next-size (alignment f))))
-	      (let ((next-size (compute-next-size size f)))
-		;; rough next offset = current offset + next-size
-		(loop (cdr fields) next-size (+ off next-size))))))))
-	  
+        (assertion-violation 'compute-offset "invalid field name" field)
+        (let ((f (car fields)))
+          (if (eq? field (car f))
+              (if (foreign-struct-descriptor? (cadr f))
+                  (offset off (foreign-struct-descriptor-alignment (cadr f)))
+                  (let ((next-size (compute-next-size size f)))
+                    (- next-size (alignment f))))
+              (let ((next-size (compute-next-size size f)))
+                ;; rough next offset = current offset + next-size
+                (loop (cdr fields) next-size (+ off next-size))))))))
+
 
 (define-syntax type->set!
   (lambda (x)
     (define (->set! k type)
       (let ((n (syntax->datum type)))
-	(if (memq n '(char unsigned-char short unsigned-short int unsigned-int
-		      long unsigned-long float double 
-		      int8_t uint8_t int16_t uint16_t
-		      int32_t uint32_t int64_t uint64_t pointer))
-	    (datum->syntax k
-	     (string->symbol (string-append (symbol->string n) "-set!")))
-	    ;; We need syntax context of the given type,
-	    ;; so use with-syntax here to keep it.
-	    (with-syntax ((t type))
-	      #'(foreign-struct-descriptor-type-set! t)))))
+        (if (memq n '(char unsigned-char short unsigned-short int unsigned-int
+                      long unsigned-long float double
+                      int8_t uint8_t int16_t uint16_t
+                      int32_t uint32_t int64_t uint64_t pointer))
+            (datum->syntax k
+             (string->symbol (string-append (symbol->string n) "-set!")))
+            ;; We need syntax context of the given type,
+            ;; so use with-syntax here to keep it.
+            (with-syntax ((t type))
+              #'(foreign-struct-descriptor-type-set! t)))))
     (syntax-case x ()
       ((k type)
        (->set! #'k #'type)))))
@@ -556,37 +556,37 @@
   (lambda (x)
     (define (->ref k type)
       (let ((n (syntax->datum type)))
-	(if (memq n '(char unsigned-char short unsigned-short int unsigned-int
-		      long unsigned-long float double 
-		      int8_t uint8_t int16_t uint16_t
-		      int32_t uint32_t int64_t uint64_t pointer))
-	    (datum->syntax k
-	     (string->symbol (string-append (symbol->string n) "-ref")))
-	    ;; We need syntax context of the given type,
-	    ;; so use with-syntax here to keep it.
-	    (with-syntax ((t type))
-	      #'(foreign-struct-descriptor-type-ref t)))))
+        (if (memq n '(char unsigned-char short unsigned-short int unsigned-int
+                      long unsigned-long float double
+                      int8_t uint8_t int16_t uint16_t
+                      int32_t uint32_t int64_t uint64_t pointer))
+            (datum->syntax k
+             (string->symbol (string-append (symbol->string n) "-ref")))
+            ;; We need syntax context of the given type,
+            ;; so use with-syntax here to keep it.
+            (with-syntax ((t type))
+              #'(foreign-struct-descriptor-type-ref t)))))
     (syntax-case x ()
       ((k type) (->ref #'k #'type)))))
 
 ;; descriptor for convenience
 (define-record-type foreign-struct-descriptor
-  (fields name				; for debug
-	  size
-	  alignment
-	  fields
-	  parent
-	  ;; these will be set after the construction...
-	  (mutable getters)
-	  (mutable setters)
-	  (mutable protocol)
-	  has-protocol?
-	  (mutable ctr)
-	  type-ref
-	  type-set!)
+  (fields name                          ; for debug
+          size
+          alignment
+          fields
+          parent
+          ;; these will be set after the construction...
+          (mutable getters)
+          (mutable setters)
+          (mutable protocol)
+          has-protocol?
+          (mutable ctr)
+          type-ref
+          type-set!)
   (protocol (lambda (n)
-	      (lambda (nm s a f p p? ref set)
-		(n nm s a f p #f #f #f p? #f ref set)))))
+              (lambda (nm s a f p p? ref set)
+                (n nm s a f p #f #f #f p? #f ref set)))))
 
 (define char-ref           bytevector-s8-ref)
 (define unsigned-char-ref  bytevector-u8-ref)
@@ -635,9 +635,9 @@
 (define int64_t-set!        bytevector-s64-native-set!)
 (define uint64_t-set!       bytevector-u64-native-set!)
 (define (pointer-set! o offset v)
-  (let ((bv (uint-list->bytevector 
-	     (list (pointer->integer v))
-	     (native-endianness)
-	     size-of-pointer)))
+  (let ((bv (uint-list->bytevector
+             (list (pointer->integer v))
+             (native-endianness)
+             size-of-pointer)))
     (bytevector-copy! bv 0 o offset size-of-pointer)))
 )

--- a/src/pffi/variable.sls
+++ b/src/pffi/variable.sls
@@ -1,20 +1,20 @@
 ;;; -*- mode:scheme; coding: utf-8; -*-
 ;;;
 ;;; src/pffi/variable.sls - Foreign variable
-;;;  
+;;;
 ;;;   Copyright (c) 2015  Takashi Kato  <ktakashi@ymail.com>
-;;;   
+;;;
 ;;;   Redistribution and use in source and binary forms, with or without
 ;;;   modification, are permitted provided that the following conditions
 ;;;   are met:
-;;;   
+;;;
 ;;;   1. Redistributions of source code must retain the above copyright
 ;;;      notice, this list of conditions and the following disclaimer.
-;;;  
+;;;
 ;;;   2. Redistributions in binary form must reproduce the above copyright
 ;;;      notice, this list of conditions and the following disclaimer in the
 ;;;      documentation and/or other materials provided with the distribution.
-;;;  
+;;;
 ;;;   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
 ;;;   "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
 ;;;   LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
@@ -26,42 +26,42 @@
 ;;;   LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
 ;;;   NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 ;;;   SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-;;;  
+;;;
 
 #!r6rs
 (library (pffi variable)
   (export define-foreign-variable)
   (import (rnrs)
-	  (for (pffi misc) expand)
-	  (pffi compat))
+          (for (pffi misc) expand)
+          (pffi compat))
 
   ;; to make FFI variable settable, we use macro
   (define-syntax define-foreign-variable
     (lambda (x)
       (define (->scheme-name name)
-	(string->symbol
-	 (string-map (lambda (c) (if (char=? c #\_) #\- c))
-		     (string-downcase (symbol->string (syntax->datum name))))))
+        (string->symbol
+         (string-map (lambda (c) (if (char=? c #\_) #\- c))
+                     (string-downcase (symbol->string (syntax->datum name))))))
       (define (derefs t)
-	(let ((s (symbol->string (syntax->datum t))))
-	  (list (string->symbol (string-append "pointer-ref-c-" s))
-		(string->symbol (string-append "pointer-set-c-" s "!")))))
+        (let ((s (symbol->string (syntax->datum t))))
+          (list (string->symbol (string-append "pointer-ref-c-" s))
+                (string->symbol (string-append "pointer-set-c-" s "!")))))
       (syntax-case x ()
-	((k lib type name)
-	 (with-syntax ((scheme-name
-			(datum->syntax #'k (->scheme-name #'name))))
-	   #'(k lib type name scheme-name)))
-	((k lib type name scheme-name)
-	 (with-syntax (((pointer-ref pointer-set!)
-			(datum->syntax #'k (derefs #'type)))
-		       ;; To avoid Guile's bug.
-		       ;; this isn't needed if macro expander works *properly*
-		       ((dummy) (generate-temporaries '(dummy))))
-	   #'(begin
-	       (define dummy (lookup-shared-object lib (symbol->string 'name)))
-	       (define-syntax scheme-name
-		 (identifier-syntax
-		  (_ (pointer-ref dummy 0))
-		  ((set! _ e) (pointer-set! dummy 0 e))))))))))
-  
+        ((k lib type name)
+         (with-syntax ((scheme-name
+                        (datum->syntax #'k (->scheme-name #'name))))
+           #'(k lib type name scheme-name)))
+        ((k lib type name scheme-name)
+         (with-syntax (((pointer-ref pointer-set!)
+                        (datum->syntax #'k (derefs #'type)))
+                       ;; To avoid Guile's bug.
+                       ;; this isn't needed if macro expander works *properly*
+                       ((dummy) (generate-temporaries '(dummy))))
+           #'(begin
+               (define dummy (lookup-shared-object lib (symbol->string 'name)))
+               (define-syntax scheme-name
+                 (identifier-syntax
+                  (_ (pointer-ref dummy 0))
+                  ((set! _ e) (pointer-set! dummy 0 e))))))))))
+
   )


### PR DESCRIPTION
* Convert tabs into spaces
* Remove invisible whitespace at ends of lines

Done by simply running `whitespace-cleanup-buffer` in Emacs.